### PR TITLE
Add comprehensive tangency tests

### DIFF
--- a/notebooks/performance_benchmark.py
+++ b/notebooks/performance_benchmark.py
@@ -27,7 +27,12 @@ def generate_ellipses(n_ellipses, seed=42):
         a = np.random.rand() * 5 + 1
         b = np.random.rand() * 5 + 1
         angle = np.random.rand() * np.pi
-        rot = np.array([[np.cos(angle), -np.sin(angle)], [np.sin(angle), np.cos(angle)]])
+        rot = np.array(
+            [
+                [np.cos(angle), -np.sin(angle)],
+                [np.sin(angle), np.cos(angle)],
+            ]
+        )
         cov = rot @ np.diag([a, b]) @ rot.T
         covs_list.append(cov)
     covs = np.array(covs_list)
@@ -44,26 +49,25 @@ ellipse_counts = [10, 50, 100, 150, 200]
 results = []
 
 for n in ellipse_counts:
-    print(f'Running benchmark for {n} ellipses...')
+    print(f"Running benchmark for {n} ellipses...")
     ellipses = generate_ellipses(n)
 
     # Time serial execution
-    serial_time = timeit.timeit(
-        lambda: pdist_tangency(ellipses, parallel=False),
-        number=5
-    ) / 5
+    serial_time = (
+        timeit.timeit(lambda: pdist_tangency(ellipses, parallel=False), number=5) / 5
+    )
 
     # Time parallel execution
-    parallel_time = timeit.timeit(
-        lambda: pdist_tangency(ellipses, parallel=True, n_jobs=-1),
-        number=5
-    ) / 5
+    parallel_time = (
+        timeit.timeit(
+            lambda: pdist_tangency(ellipses, parallel=True, n_jobs=-1), number=5
+        )
+        / 5
+    )
 
-    results.append({
-        'n_ellipses': n,
-        'serial_time': serial_time,
-        'parallel_time': parallel_time
-    })
+    results.append(
+        {"n_ellipses": n, "serial_time": serial_time, "parallel_time": parallel_time}
+    )
 
 df_results = pd.DataFrame(results)
 print(df_results)
@@ -73,11 +77,21 @@ print(df_results)
 
 
 plt.figure(figsize=(10, 6))
-plt.plot(df_results['n_ellipses'], df_results['serial_time'], marker='o', label='Serial')
-plt.plot(df_results['n_ellipses'], df_results['parallel_time'], marker='o', label='Parallel (all cores)')
-plt.title('pdist_tangency Performance: Serial vs. Parallel')
-plt.xlabel('Number of Ellipses')
-plt.ylabel('Execution Time (seconds)')
+plt.plot(
+    df_results["n_ellipses"],
+    df_results["serial_time"],
+    marker="o",
+    label="Serial",
+)
+plt.plot(
+    df_results["n_ellipses"],
+    df_results["parallel_time"],
+    marker="o",
+    label="Parallel (all cores)",
+)
+plt.title("pdist_tangency Performance: Serial vs. Parallel")
+plt.xlabel("Number of Ellipses")
+plt.ylabel("Execution Time (seconds)")
 plt.legend()
 plt.grid(True)
 plt.show()

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 from ellphi import coef_from_axes, tangency
+from ellphi.solver import quad_eval
 
 
 # -----------------------------------------------------------------------------
@@ -46,3 +47,136 @@ def test_newton_requires_x0():
     q = coef_from_axes([1, 0], 1, 1, 0)
     with pytest.raises(ValueError):
         tangency(p, q, method="newton")
+
+
+# -----------------------------------------------------------------------------
+# 4. Analytic checks for circles (closed form available)
+# -----------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    "center_p, center_q, radius_p, radius_q",
+    [
+        ((0.0, 0.0), (2.0, 0.0), 1.0, 1.0),
+        ((1.5, -0.5), (5.5, -0.5), 0.5, 1.5),
+        ((-1.0, 3.0), (-1.0, -1.0), 2.5, 0.5),
+        ((0.0, 0.0), (0.0, 0.0), 1.0, 2.0),
+    ],
+)
+def test_circle_tangency_matches_closed_form(center_p, center_q, radius_p, radius_q):
+    center_p = np.asarray(center_p, dtype=float)
+    center_q = np.asarray(center_q, dtype=float)
+    p = coef_from_axes(center_p, radius_p, radius_p, 0.0)
+    q = coef_from_axes(center_q, radius_q, radius_q, 0.0)
+
+    res = tangency(p, q)
+
+    distance = np.linalg.norm(center_p - center_q)
+    expected_t = distance / (radius_p + radius_q) if distance else 0.0
+    assert res.t == pytest.approx(expected_t, rel=1e-9, abs=1e-12)
+
+    if distance == 0.0:
+        assert res.point.tolist() == pytest.approx(center_p.tolist(), rel=1e-9)
+    else:
+        direction = (center_q - center_p) / distance
+        expected_point = center_p + direction * (radius_p * expected_t)
+        assert res.point.tolist() == pytest.approx(
+            expected_point.tolist(), rel=1e-9, abs=1e-12
+        )
+
+
+# -----------------------------------------------------------------------------
+# 5. Axis-aligned ellipses: tangency along the major axis direction
+# -----------------------------------------------------------------------------
+def test_axis_aligned_ellipses_have_expected_t():
+    center_p = np.array([0.0, 0.0])
+    center_q = np.array([10.0, 0.0])
+    r0_p, r1_p = 3.0, 1.0
+    r0_q, r1_q = 1.0, 0.75
+
+    p = coef_from_axes(center_p, r0_p, r1_p, 0.0)
+    q = coef_from_axes(center_q, r0_q, r1_q, 0.0)
+
+    res = tangency(p, q)
+
+    expected_t = np.linalg.norm(center_q - center_p) / (r0_p + r0_q)
+    assert res.t == pytest.approx(expected_t, rel=1e-12)
+    assert res.point.tolist() == pytest.approx([7.5, 0.0], rel=1e-12)
+    assert res.mu == pytest.approx(r0_q / (r0_p + r0_q), rel=1e-12)
+
+
+# -----------------------------------------------------------------------------
+# 6. Rotating the entire configuration does not change the tangency scale
+# -----------------------------------------------------------------------------
+@pytest.mark.parametrize("angle", [0.2, 0.8, 1.3])
+def test_rotational_invariance(angle):
+    base_center_p = np.array([0.0, 0.0])
+    base_center_q = np.array([10.0, 0.0])
+    r0_p, r1_p = 3.0, 1.0
+    r0_q, r1_q = 1.0, 0.75
+    base_t = np.linalg.norm(base_center_q - base_center_p) / (r0_p + r0_q)
+    base_point = np.array([base_t * r0_p, 0.0])
+
+    rot = np.array([[np.cos(angle), -np.sin(angle)], [np.sin(angle), np.cos(angle)]])
+    center_p = base_center_p @ rot.T
+    center_q = base_center_q @ rot.T
+    expected_point = base_point @ rot.T
+
+    p = coef_from_axes(center_p, r0_p, r1_p, angle)
+    q = coef_from_axes(center_q, r0_q, r1_q, angle)
+
+    res = tangency(p, q)
+
+    assert res.t == pytest.approx(base_t, rel=1e-12)
+    assert res.point.tolist() == pytest.approx(expected_point.tolist(), rel=1e-12)
+    assert res.mu == pytest.approx(r0_q / (r0_p + r0_q), rel=1e-12)
+
+
+# -----------------------------------------------------------------------------
+# 7. Generic properties at the tangency point
+# -----------------------------------------------------------------------------
+
+
+def _gradient_from_coef(coef: np.ndarray, point: np.ndarray) -> np.ndarray:
+    a, b, c, d, e, _ = coef
+    x, y = point
+    return np.array([2 * a * x + 2 * b * y + 2 * d, 2 * b * x + 2 * c * y + 2 * e])
+
+
+def test_tangency_point_satisfies_quadratic_and_normal_alignment():
+    rng = np.random.default_rng(2024)
+
+    for _ in range(10):
+        center_p = rng.uniform(-2.0, 2.0, size=2)
+
+        # Draw a direction vector ensuring sufficient separation between centres
+        while True:
+            direction = rng.normal(size=2)
+            norm = np.linalg.norm(direction)
+            if norm > 1e-8:
+                direction /= norm
+                break
+
+        distance = rng.uniform(0.5, 3.0)
+        center_q = center_p + direction * distance
+
+        r0_p, r1_p = rng.uniform(0.5, 2.0, size=2)
+        r0_q, r1_q = rng.uniform(0.5, 2.0, size=2)
+        theta_p, theta_q = rng.uniform(0.0, np.pi, size=2)
+
+        p = coef_from_axes(center_p, r0_p, r1_p, theta_p)
+        q = coef_from_axes(center_q, r0_q, r1_q, theta_q)
+
+        res = tangency(p, q)
+
+        assert res.t >= 0.0
+        assert -1e-9 <= res.mu <= 1.0 + 1e-9
+
+        value_p = quad_eval(p, res.point)
+        value_q = quad_eval(q, res.point)
+        assert value_p == pytest.approx(res.t**2, rel=1e-9, abs=1e-9)
+        assert value_q == pytest.approx(res.t**2, rel=1e-9, abs=1e-9)
+
+        grad_p = _gradient_from_coef(p, res.point)
+        grad_q = _gradient_from_coef(q, res.point)
+        cross = grad_p[0] * grad_q[1] - grad_p[1] * grad_q[0]
+        assert cross == pytest.approx(0.0, abs=1e-8)
+        assert np.dot(grad_p, grad_q) <= 1e-8


### PR DESCRIPTION
## Summary
- add analytic and property-based tests covering ellipse tangency timing, points, and multipliers
- verify tangency points satisfy the quadratic equations and share aligned normals
- reformat the performance benchmark helper script to satisfy the style checks

## Testing
- poetry run pytest
- poetry run flake8
- poetry run black src tests
- poetry run mypy src tests

------
https://chatgpt.com/codex/tasks/task_e_68ce7ed823e08323919ddb0a6c618047