### PR TITLE
Handle missing package metadata gracefully

### DIFF
--- a/src/ellphi/__init__.py
+++ b/src/ellphi/__init__.py
@@ -8,7 +8,7 @@ Re-exports the most frequently used symbols so users can::
     el.tangency(...)
 """
 
-from importlib.metadata import version as _version
+from importlib.metadata import PackageNotFoundError, version as _version
 
 # geometry
 from .geometry import (
@@ -47,4 +47,7 @@ __all__ = [
     "TangencyResult",
 ]
 
-__version__ = _version(__name__)
+try:
+    __version__ = _version(__name__)
+except PackageNotFoundError:
+    __version__ = "0+unknown"

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,34 @@
+"""Tests for the :mod:`ellphi` package initialisation."""
+
+import importlib
+import sys
+from importlib.metadata import PackageNotFoundError
+
+
+def test_import_without_package_metadata(monkeypatch):
+    """The package should fall back to a sensible version when metadata is missing."""
+
+    def _raise_version(_name):
+        raise PackageNotFoundError
+
+    monkeypatch.setattr("importlib.metadata.version", _raise_version)
+
+    saved_modules = {
+        name: module
+        for name, module in sys.modules.items()
+        if name == "ellphi" or name.startswith("ellphi.")
+    }
+
+    for name in list(saved_modules):
+        sys.modules.pop(name, None)
+
+    try:
+        module = importlib.import_module("ellphi")
+        assert module.__version__ == "0+unknown"
+    finally:
+        for name in [
+            key for key in sys.modules if key == "ellphi" or key.startswith("ellphi.")
+        ]:
+            sys.modules.pop(name, None)
+
+        sys.modules.update(saved_modules)


### PR DESCRIPTION
## Summary
- handle missing package metadata by falling back to a default version string when package metadata is unavailable
- add a regression test that simulates missing metadata and verifies the fallback behaviour

## Testing
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68ce9ce9d80483238c7c702ea49e8e22