### PR TITLE
Fix EllipseCloud rescale eigenvalue usage

### DIFF
--- a/src/ellphi/ellcloud.py
+++ b/src/ellphi/ellcloud.py
@@ -160,7 +160,8 @@ class EllipseCloud:
         Apply rescaling to all the ellipses.
         The supported method is "median" or "average".
         """
-        scales = numpy.sqrt(numpy.linalg.eigh(self.cov).eigenvalues)
+        eigvals = numpy.linalg.eigvalsh(self.cov)
+        scales = numpy.sqrt(eigvals)
         if method == "median":
             ell_scales = numpy.median(scales, axis=0)
         elif method == "average":
@@ -173,7 +174,7 @@ class EllipseCloud:
         ell_scale = ell_scales[1] ** 2 / ell_scales[0]
         self.cov /= ell_scale**2
         self.coef *= ell_scale**2
-        return ell_scale
+        return float(ell_scale)
 
 
 # alias

--- a/tests/test_ellcloud_rescale.py
+++ b/tests/test_ellcloud_rescale.py
@@ -1,0 +1,23 @@
+"""Regression tests for :mod:`ellphi.ellcloud`."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from .factories import random_cloud
+
+
+def test_rescale_returns_float_and_updates_arrays():
+    """``EllipseCloud.rescale`` returns a float and rescales members."""
+
+    rng = np.random.default_rng(2024)
+    cloud = random_cloud(rng, n_ellipses=5)
+
+    cov_before = cloud.cov.copy()
+    coef_before = cloud.coef.copy()
+
+    scale = cloud.rescale()
+
+    assert isinstance(scale, float)
+    np.testing.assert_allclose(cloud.cov, cov_before / scale**2)
+    np.testing.assert_allclose(cloud.coef, coef_before * scale**2)


### PR DESCRIPTION
## Summary
- replace the chained eigenvalue access in `EllipseCloud.rescale` with an explicit call to `numpy.linalg.eigvalsh`
- ensure the method returns a Python float and is covered by a regression test exercising the scaling behaviour

## Testing
- `poetry run pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ce9d1f7a348323923c2a50718d679d