### PR TITLE
Fix LocalCov neighbourhood sizing and extend tests

### DIFF
--- a/src/ellphi/ellcloud.py
+++ b/src/ellphi/ellcloud.py
@@ -206,6 +206,11 @@ class LocalCov:
             merged into a single ellipse.
         """
         k = self.k
+        if k < 2:
+            raise ValueError(
+                "Local covariance requires at least two neighbours (k >= 2); "
+                f"got k={k}."
+            )
         d = squareform(pdist(X))  # Euclidean distance matrix
         # argsort したものから :near だけとると重複が生じるので削る
         near_subsets = numpy.unique(numpy.argsort(d, axis=1)[:, :k], axis=0)
@@ -215,6 +220,12 @@ class LocalCov:
         knbd = X[unique_subsets]
         means = numpy.mean(knbd, axis=1)
         rel_nbd = knbd - means[:, None, :]
-        covs = rel_nbd.transpose(0, 2, 1) @ rel_nbd / (k - 1)
+        nbd_size = knbd.shape[1]
+        if nbd_size < 2:
+            raise ValueError(
+                "Local covariance requires neighbourhoods with at least two "
+                f"points; got {nbd_size}."
+            )
+        covs = rel_nbd.transpose(0, 2, 1) @ rel_nbd / (nbd_size - 1)
         coefs = coef_from_cov(means, covs)
         return EllipseCloud(coefs, means, covs, k, unique_subsets)

--- a/tests/test_ellcloud.py
+++ b/tests/test_ellcloud.py
@@ -1,0 +1,30 @@
+import numpy as np
+import pytest
+
+from ellphi.ellcloud import EllipseCloud
+
+
+def test_local_cov_uses_actual_neighbourhood_size():
+    # Request more neighbours than available to trigger neighbourhood truncation.
+    X = np.array([[0.0, 0.0], [2.0, 0.0], [1.0, 1.5]])
+
+    ellcloud = EllipseCloud.from_local_cov(X, k=5)
+
+    # Only one unique neighbourhood should exist and it should contain all points.
+    assert ellcloud.cov.shape[0] == 1
+    expected_cov = np.cov(X, rowvar=False, bias=False)
+    assert ellcloud.cov[0] == pytest.approx(expected_cov)
+
+
+def test_local_cov_requires_k_at_least_two():
+    X = np.array([[0.0, 0.0], [1.0, 1.0]])
+
+    with pytest.raises(ValueError, match="k >= 2"):
+        EllipseCloud.from_local_cov(X, k=1)
+
+
+def test_local_cov_requires_two_point_neighbourhood():
+    X = np.array([[0.0, 0.0]])
+
+    with pytest.raises(ValueError, match="at least two points"):
+        EllipseCloud.from_local_cov(X, k=2)


### PR DESCRIPTION
## Summary
- ensure LocalCov validates k before computing neighbourhoods and uses the true neighbour count when normalising covariances
- add regression tests covering truncated neighbourhood sizes, k=1 validation, and insufficient point clouds

## Testing
- poetry run black src tests
- poetry run flake8
- poetry run mypy src tests
- poetry run pytest


------
https://chatgpt.com/codex/tasks/task_e_68ce9d76bdf08323af1977d67bbf4efc