### PR TITLE
Add error analysis to performance benchmark notebook

### DIFF
--- a/notebooks/performance_benchmark.ipynb
+++ b/notebooks/performance_benchmark.ipynb
@@ -24,7 +24,8 @@
     "\n",
     "from ellphi.ellcloud import EllipseCloud\n",
     "from ellphi.solver import pdist_tangency, tangency, has_cpp_backend\n",
-    "from ellphi.geometry import coef_from_cov\n"
+    "from ellphi.geometry import coef_from_cov\n",
+    "from ellphi._solver_python import quad_eval\n"
    ]
   },
   {
@@ -385,6 +386,64 @@
     "plt.grid(axis='y', linestyle='--', alpha=0.3)\n",
     "plt.show()\n",
     "tangency_df\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7f0c3bc",
+   "metadata": {},
+   "source": [
+    "## Error analysis / \u8aa4\u5dee\u89e3\u6790\n",
+    "\n",
+    "To verify that the tangency results satisfy each ellipse polynomial, we repeat the computation several times and report the mean and median absolute and relative errors for both the Python and C++ backends. The analysis also monitors the difference between the polynomial evaluations of the two ellipses to ensure they coincide.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4fca9242",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "error_trials = 1000\n",
+    "\n",
+    "\n",
+    "def compute_error_statistics(backend: str, trials: int = error_trials) -> dict[str, float]:\n",
+    "    abs_errors: list[float] = []\n",
+    "    relative_errors: list[float] = []\n",
+    "    poly_differences: list[float] = []\n",
+    "\n",
+    "    for _ in range(trials):\n",
+    "        result = tangency(pcoef, qcoef, backend=backend)\n",
+    "        expected = result.t ** 2\n",
+    "        denom = max(abs(expected), float(np.finfo(float).eps))\n",
+    "\n",
+    "        eval_p = quad_eval(pcoef, result.point)\n",
+    "        eval_q = quad_eval(qcoef, result.point)\n",
+    "        poly_differences.append(abs(eval_p - eval_q))\n",
+    "\n",
+    "        for value in (eval_p, eval_q):\n",
+    "            diff = value - expected\n",
+    "            abs_errors.append(abs(diff))\n",
+    "            relative_errors.append(abs(diff) / denom)\n",
+    "\n",
+    "    return {\n",
+    "        \"backend\": backend,\n",
+    "        \"abs_error_mean\": float(np.mean(abs_errors)),\n",
+    "        \"abs_error_median\": float(np.median(abs_errors)),\n",
+    "        \"relative_error_mean\": float(np.mean(relative_errors)),\n",
+    "        \"relative_error_median\": float(np.median(relative_errors)),\n",
+    "        \"poly_eval_difference_mean\": float(np.mean(poly_differences)),\n",
+    "        \"poly_eval_difference_median\": float(np.median(poly_differences)),\n",
+    "    }\n",
+    "\n",
+    "\n",
+    "error_statistics = [compute_error_statistics(\"python\")]\n",
+    "if cpp_available:\n",
+    "    error_statistics.append(compute_error_statistics(\"cpp\"))\n",
+    "\n",
+    "error_summary_df = pd.DataFrame(error_statistics)\n",
+    "error_summary_df\n"
    ]
   }
  ],


### PR DESCRIPTION
## Summary
- import `quad_eval` in the performance benchmark notebook
- add an error analysis section that repeats tangency calculations and reports mean/median absolute and relative errors for each backend

## Testing
- `poetry run pytest`
- `poetry run flake8`
- `poetry run black src tests`
- `poetry run mypy src tests`


------
https://chatgpt.com/codex/tasks/task_e_68ceca78fa348323bdafa62c0fab801f