### PR TITLE
Align CI Python versions with project requirements

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v4
@@ -31,6 +31,8 @@ jobs:
     # -- Poetry ------------------------------------------------------
     - name: Install Poetry
       run: pip install --upgrade poetry
+      env:
+        POETRY_VIRTUALENVS_PREFER_ACTIVE_PYTHON: "true"
 
     - name: Cache Poetry env
       uses: actions/cache@v3
@@ -40,23 +42,35 @@ jobs:
 
     - name: Install project (dev extras)
       run: poetry install --with dev
+      env:
+        POETRY_VIRTUALENVS_PREFER_ACTIVE_PYTHON: "true"
 
     - name: Ensure build toolchain
       run: poetry run python -m pip install --upgrade pip setuptools
+      env:
+        POETRY_VIRTUALENVS_PREFER_ACTIVE_PYTHON: "true"
 
     - name: Build tangency C++ backend
       run: poetry run python build_tangency_cpp.py
+      env:
+        POETRY_VIRTUALENVS_PREFER_ACTIVE_PYTHON: "true"
 
     # -- Lint / Format ----------------------------------------------
     - name: flake8
       run: poetry run flake8 src tests
+      env:
+        POETRY_VIRTUALENVS_PREFER_ACTIVE_PYTHON: "true"
 
     - name: black check
       run: poetry run black --check src tests
+      env:
+        POETRY_VIRTUALENVS_PREFER_ACTIVE_PYTHON: "true"
 
     # -- Tests ------------------------------------------------------
     - name: pytest
       run: poetry run pytest -q
+      env:
+        POETRY_VIRTUALENVS_PREFER_ACTIVE_PYTHON: "true"
 
   # 3.11 限定で mypy
   typecheck:
@@ -72,6 +86,8 @@ jobs:
 
     - name: Install Poetry
       run: pip install --upgrade poetry
+      env:
+        POETRY_VIRTUALENVS_PREFER_ACTIVE_PYTHON: "true"
 
     - name: Cache Poetry env
       uses: actions/cache@v3
@@ -81,6 +97,10 @@ jobs:
 
     - name: Install project (dev extras)
       run: poetry install --with dev      # stub も OK
+      env:
+        POETRY_VIRTUALENVS_PREFER_ACTIVE_PYTHON: "true"
 
     - name: mypy
       run: poetry run mypy src
+      env:
+        POETRY_VIRTUALENVS_PREFER_ACTIVE_PYTHON: "true"

--- a/build_tangency_cpp.py
+++ b/build_tangency_cpp.py
@@ -44,10 +44,15 @@ def _ensure_parent(path: Path) -> None:
 
 class _TangencyExtension(Extension):
     def __init__(self) -> None:
+        libraries: list[str] = []
+        if sys.platform.startswith("linux"):
+            libraries.append("stdc++")
+
         super().__init__(
             name=_LIB_NAME,
             sources=[str(_source_path())],
             language="c++",
+            libraries=libraries,
         )
 
 


### PR DESCRIPTION
## Summary
- update the test matrix to cover the supported Python versions (3.10–3.12)
- configure Poetry commands to reuse the runner-provided interpreter so the C++ tangency build runs under each matrix version

## Testing
- `poetry install --with dev` *(fails: network access to pypi.org is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cf5c8ce17883239a1a9ff67d38532a