### PR TITLE
Refactor solve_mu root finding orchestration

### DIFF
--- a/src/ellphi/_solver_python.py
+++ b/src/ellphi/_solver_python.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 """Pure Python tangency solver backend."""
 
 from collections import namedtuple
+from functools import partial
 from itertools import combinations
-from typing import TYPE_CHECKING, Callable, Iterator, Literal, Tuple, cast
+from typing import TYPE_CHECKING, Any, Callable, Iterator, Literal, Tuple, cast
 
 import numpy
 from joblib import Parallel, delayed  # type: ignore
@@ -78,6 +79,9 @@ def _target_prime(mu: float, p: numpy.ndarray, q: numpy.ndarray) -> float:
     return 2.0 * numerator / det
 
 
+MethodName = Literal["bisect", "brentq", "brenth", "newton"]
+
+
 def solve_mu(
     p: numpy.ndarray,
     q: numpy.ndarray,
@@ -86,30 +90,24 @@ def solve_mu(
     bracket: Tuple[float, float] = (0.0, 1.0),
     x0: float | None = None,
 ) -> float:
-    curry_f: Callable[[float], float] = lambda mu: _target(mu, p, q)
-    curry_df: Callable[[float], float] = lambda mu: _target_prime(mu, p, q)
+    target = cast(Callable[[float], float], partial(_target, p=p, q=q))
+    target_prime = cast(Callable[[float], float], partial(_target_prime, p=p, q=q))
+
+    def solve_single_stage(method_name: MethodName, **kwargs: Any) -> float:
+        if method_name == "newton":
+            kwargs.setdefault("fprime", target_prime)
+        result = root_scalar(target, method=method_name, **kwargs)
+        return float(result.root)
+
     if method == "brentq+newton":
-        mu0 = root_scalar(curry_f, bracket=bracket, method="brentq", maxiter=8).root
-        mu = root_scalar(
-            curry_f,
-            x0=mu0,
-            method="newton",
-            fprime=curry_df,
-            maxiter=3,
-        ).root
-        return float(mu)
+        mu0 = solve_single_stage("brentq", bracket=bracket, maxiter=8)
+        return solve_single_stage("newton", x0=mu0, maxiter=3)
     if method in {"bisect", "brentq", "brenth"}:
-        return float(
-            root_scalar(
-                curry_f,
-                bracket=bracket,
-                method=cast(Literal["bisect", "brentq", "brenth"], method),
-            ).root
-        )
+        return solve_single_stage(cast(MethodName, method), bracket=bracket)
     if method == "newton":
         if x0 is None:
             raise ValueError("x0 must be provided for Newton method")
-        return float(root_scalar(curry_f, x0=x0, method="newton", fprime=curry_df).root)
+        return solve_single_stage("newton", x0=x0)
     raise ValueError(f"Unknown method: {method}")
 
 


### PR DESCRIPTION
## Summary
- refactor the Python solver's `solve_mu` routine to centralize root-finding dispatch with reusable helper logic

## Testing
- poetry run black src tests
- poetry run flake8
- poetry run mypy src tests
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf63f209d88323a55f00fcd75b197e