### PR TITLE
Optimize LocalCov neighbourhood deduplication

### DIFF
--- a/src/ellphi/ellcloud.py
+++ b/src/ellphi/ellcloud.py
@@ -226,11 +226,9 @@ class LocalCov:
                 f"got k={k}."
             )
         d = squareform(pdist(X))  # Euclidean distance matrix
-        # argsort したものから :near だけとると重複が生じるので削る
-        near_subsets = numpy.unique(numpy.argsort(d, axis=1)[:, :k], axis=0)
-        # 各サブセットをソートしてタプルに変換
-        sorted_subsets = [tuple(sorted(subset)) for subset in near_subsets]
-        unique_subsets = numpy.unique(sorted_subsets, axis=0)  # 重複を取り除く
+        neighbour_indices = numpy.argsort(d, axis=1)[:, :k]
+        sorted_subsets = numpy.sort(neighbour_indices, axis=1)
+        unique_subsets = numpy.unique(sorted_subsets, axis=0)
         knbd = X[unique_subsets]
         means = numpy.mean(knbd, axis=1)
         rel_nbd = knbd - means[:, None, :]

--- a/tests/test_ellcloud.py
+++ b/tests/test_ellcloud.py
@@ -28,3 +28,37 @@ def test_local_cov_requires_two_point_neighbourhood():
 
     with pytest.raises(ValueError, match="at least two points"):
         EllipseCloud.from_local_cov(X, k=2)
+
+
+def test_local_cov_merges_permuted_neighbourhoods():
+    X = np.array(
+        [
+            [0.0, 0.0],
+            [1.0, 0.0],
+            [0.5, np.sqrt(3.0) / 2.0],
+        ]
+    )
+
+    ellcloud = EllipseCloud.from_local_cov(X, k=3)
+
+    assert ellcloud.nbd.shape == (1, 3)
+    assert np.array_equal(ellcloud.nbd[0], np.array([0, 1, 2]))
+
+
+def test_local_cov_merges_identical_neighbourhoods():
+    X = np.array(
+        [
+            [0.0, 0.0],
+            [1.0, 0.0],
+            [0.5, np.sqrt(3.0) / 2.0],
+            [5.0, 0.0],
+            [6.0, 0.0],
+            [5.5, np.sqrt(3.0) / 2.0],
+        ]
+    )
+
+    ellcloud = EllipseCloud.from_local_cov(X, k=3)
+
+    assert ellcloud.nbd.shape == (2, 3)
+    assert np.array_equal(ellcloud.nbd, np.array([[0, 1, 2], [3, 4, 5]]))
+    assert np.array_equal(ellcloud.nbd, np.sort(ellcloud.nbd, axis=1))


### PR DESCRIPTION
## Summary
- replace the Python loop based neighbourhood standardisation with vectorised NumPy sorting and uniqueness in `LocalCov`
- add regression tests covering permuted and repeated neighbourhood sets to ensure deduplication behaviour

## Testing
- poetry run black src tests
- poetry run flake8
- poetry run mypy src tests
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf8341ec6c8323aa295ef83be57a3c