### PR TITLE
Rename tangency pencil state to TangentPencil

### DIFF
--- a/src/ellphi/_solver_python.py
+++ b/src/ellphi/_solver_python.py
@@ -11,6 +11,8 @@ import numpy
 from joblib import Parallel, delayed  # type: ignore
 from scipy.optimize import root_scalar
 
+from ._tangent_pencil import build_tangent_pencil, target_prime_from_pencil
+
 if TYPE_CHECKING:  # pragma: no cover - only for typing
     from ellphi.ellcloud import EllipseCloud
 
@@ -62,21 +64,8 @@ def _target(mu: float, p: numpy.ndarray, q: numpy.ndarray) -> float:
 def _target_prime(mu: float, p: numpy.ndarray, q: numpy.ndarray) -> float:
     """Exact derivative of `_target`."""
 
-    coef = pencil(p, q, mu)
-    a, b, c, d, e, _ = coef
-    diff = p - q
-
-    det = a * c - b**2
-    if det == 0:
-        raise ZeroDivisionError("Degenerate conic (determinant zero)")
-    xc = numpy.array([(b * e - c * d) / det, (b * d - a * e) / det])
-
-    diff_mat = numpy.array([[diff[0], diff[1]], [diff[1], diff[2]]])
-    A_xprime = -(diff_mat @ xc + diff[3:5])
-
-    v0, v1 = A_xprime
-    numerator = c * v0**2 - 2 * b * v0 * v1 + a * v1**2
-    return 2.0 * numerator / det
+    pencil = build_tangent_pencil(mu, p, q)
+    return target_prime_from_pencil(pencil, p, q)
 
 
 SingleStageMethodName = Literal["bisect", "brentq", "brenth", "newton"]

--- a/src/ellphi/_tangent_pencil.py
+++ b/src/ellphi/_tangent_pencil.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+"""Utilities describing the tangent pencil at the solution ``μ``."""
+
+from dataclasses import dataclass
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class TangentPencil:
+    """Geometry of the conic pencil ``(1-μ) p + μ q`` at the solution ``μ``."""
+
+    coef: np.ndarray
+    quad: np.ndarray
+    linear: np.ndarray
+    det: float
+    inv_quad: np.ndarray
+    center: np.ndarray
+
+
+def quad_matrix(coef: np.ndarray) -> np.ndarray:
+    """Return the 2×2 quadratic-form matrix associated with ``coef``."""
+
+    a, b, c = coef[:3]
+    return np.array([[a, b], [b, c]], dtype=float)
+
+
+def linear_vector(coef: np.ndarray) -> np.ndarray:
+    """Return the linear-term vector associated with ``coef``."""
+
+    return np.array(coef[3:5], dtype=float)
+
+
+def build_tangent_pencil(mu: float, p: np.ndarray, q: np.ndarray) -> TangentPencil:
+    """Construct the tangent pencil for ``μ`` from ``p`` and ``q``."""
+
+    coef = (1.0 - mu) * p + mu * q
+    quad = quad_matrix(coef)
+    linear = linear_vector(coef)
+    det = float(quad[0, 0] * quad[1, 1] - quad[0, 1] ** 2)
+    if det == 0.0:
+        raise ZeroDivisionError("Degenerate conic (determinant zero)")
+    inv_quad = (1.0 / det) * np.array(
+        [[quad[1, 1], -quad[0, 1]], [-quad[0, 1], quad[0, 0]]],
+        dtype=float,
+    )
+    center = -inv_quad @ linear
+    return TangentPencil(
+        coef=coef, quad=quad, linear=linear, det=det, inv_quad=inv_quad, center=center
+    )
+
+
+def target_prime_from_pencil(
+    pencil: TangentPencil, p: np.ndarray, q: np.ndarray
+) -> float:
+    """Evaluate ``∂F/∂μ`` for the tangency equation using cached geometry."""
+
+    diff = p - q
+    diff_mat = quad_matrix(diff)
+    diff_vec = linear_vector(diff)
+    residual = -(diff_mat @ pencil.center + diff_vec)
+    return float(2.0 * residual @ pencil.inv_quad @ residual)
+
+
+def center_jacobian(pencil: TangentPencil) -> np.ndarray:
+    """Return ``∂x_c/∂r`` where ``r`` are pencil coefficients."""
+
+    jac = np.zeros((6, 2), dtype=float)
+    basis_matrices = (
+        np.array([[1.0, 0.0], [0.0, 0.0]], dtype=float),
+        np.array([[0.0, 1.0], [1.0, 0.0]], dtype=float),
+        np.array([[0.0, 0.0], [0.0, 1.0]], dtype=float),
+    )
+    basis_vectors = (
+        np.array([1.0, 0.0], dtype=float),
+        np.array([0.0, 1.0], dtype=float),
+    )
+
+    for idx in range(3):
+        d_quad = basis_matrices[idx]
+        rhs = d_quad @ pencil.center
+        jac[idx] = -(pencil.inv_quad @ rhs)
+
+    jac[3] = -(pencil.inv_quad @ basis_vectors[0])
+    jac[4] = -(pencil.inv_quad @ basis_vectors[1])
+    # The constant term does not influence the center.
+    return jac

--- a/src/ellphi/differentiable_solver.py
+++ b/src/ellphi/differentiable_solver.py
@@ -1,9 +1,19 @@
 from __future__ import annotations
 from typing import Tuple
-import numpy as np
-from .solver import solve_mu
 
-__all__ = ["solve_mu_numerical_diff"]
+import numpy as np
+
+from ._tangent_pencil import (
+    TangentPencil,
+    build_tangent_pencil,
+    center_jacobian,
+    linear_vector,
+    quad_matrix,
+    target_prime_from_pencil,
+)
+from .solver import MethodName, solve_mu
+
+__all__ = ["solve_mu_gradients", "solve_mu_numerical_diff"]
 
 
 def solve_mu_numerical_diff(
@@ -45,3 +55,65 @@ def solve_mu_numerical_diff(
         d_mu_dq[i] = (solve_mu(p, q_plus_h) - solve_mu(p, q_minus_h)) / (2 * h)
 
     return d_mu_dp, d_mu_dq
+
+
+def solve_mu_gradients(
+    p: np.ndarray,
+    q: np.ndarray,
+    *,
+    mu: float | None = None,
+    method: MethodName = "brentq+newton",
+    bracket: Tuple[float, float] = (0.0, 1.0),
+    x0: float | None = None,
+) -> Tuple[float, np.ndarray, np.ndarray]:
+    """Return ``μ`` and its partial derivatives with respect to ``p`` and ``q``.
+
+    Parameters
+    ----------
+    p, q:
+        Coefficient vectors defining the two conics.
+    mu:
+        Optional pre-computed value of ``μ``. When omitted the function
+        solves for ``μ`` using :func:`ellphi.solver.solve_mu` with the
+        supplied keyword arguments.
+    method, bracket, x0:
+        Parameters forwarded to :func:`ellphi.solver.solve_mu` when ``mu``
+        is not given.
+
+    Returns
+    -------
+    Tuple[float, np.ndarray, np.ndarray]
+        The solved ``μ`` together with ``∂μ/∂p`` and ``∂μ/∂q``.
+    """
+
+    if mu is None:
+        mu = solve_mu(p, q, method=method, bracket=bracket, x0=x0)
+
+    pencil: TangentPencil = build_tangent_pencil(mu, p, q)
+    diff = p - q
+    diff_mat = quad_matrix(diff)
+    diff_vec = linear_vector(diff)
+    residual = -(diff_mat @ pencil.center + diff_vec)
+
+    dF_dmu = target_prime_from_pencil(pencil, p, q)
+    if np.isclose(dF_dmu, 0.0):
+        raise ZeroDivisionError("Derivative with respect to mu is numerically zero")
+
+    phi_x = -2.0 * residual
+    xc0, xc1 = pencil.center
+    base = np.array([xc0**2, 2.0 * xc0 * xc1, xc1**2, 2.0 * xc0, 2.0 * xc1, 1.0])
+
+    jac_center = center_jacobian(pencil)
+    dx_dp = (1.0 - mu) * jac_center
+    dx_dq = mu * jac_center
+
+    chain_dp = dx_dp @ phi_x
+    chain_dq = dx_dq @ phi_x
+
+    dF_dp = base + chain_dp
+    dF_dq = -base + chain_dq
+
+    d_mu_dp = -dF_dp / dF_dmu
+    d_mu_dq = -dF_dq / dF_dmu
+
+    return mu, d_mu_dp, d_mu_dq

--- a/tests/test_differentiable_solver.py
+++ b/tests/test_differentiable_solver.py
@@ -1,6 +1,10 @@
 import numpy as np
+import pytest
 
-from ellphi.differentiable_solver import solve_mu_numerical_diff
+from ellphi.differentiable_solver import (
+    solve_mu_gradients,
+    solve_mu_numerical_diff,
+)
 from ellphi.solver import solve_mu
 
 from .factories import random_coef_pair
@@ -50,3 +54,30 @@ def test_numerical_differentiation(rng):
         atol=1e-8,
         err_msg="Central and forward difference for dq are not close enough.",
     )
+
+
+def test_analytic_gradients_match_central_difference(rng):
+    """The analytic gradients agree with central differences."""
+
+    for _ in range(5):
+        p, q = random_coef_pair(rng)
+        mu, d_mu_dp, d_mu_dq = solve_mu_gradients(p, q)
+        d_mu_dp_num, d_mu_dq_num = solve_mu_numerical_diff(p, q)
+
+        np.testing.assert_allclose(
+            d_mu_dp,
+            d_mu_dp_num,
+            rtol=1e-6,
+            atol=1e-8,
+            err_msg="Analytic and numerical gradients w.r.t. p differ.",
+        )
+        np.testing.assert_allclose(
+            d_mu_dq,
+            d_mu_dq_num,
+            rtol=1e-6,
+            atol=1e-8,
+            err_msg="Analytic and numerical gradients w.r.t. q differ.",
+        )
+
+        mu_direct = solve_mu(p, q)
+        assert mu == pytest.approx(mu_direct)


### PR DESCRIPTION
## Summary
- rename the cached tangency helper to the TangentPencil dataclass and adjust module naming
- update solver and differentiable gradient utilities to use the TangentPencil terminology

## Testing
- poetry run black src tests
- poetry run flake8
- poetry run mypy src tests
- poetry run pytest

------
https://chatgpt.com/codex/tasks/task_e_68cf837b0f808323b64fcd0041847855