### PR TITLE
Extend ellipsoid solver to n dimensions

### DIFF
--- a/src/ellphi/_solver_python.py
+++ b/src/ellphi/_solver_python.py
@@ -5,13 +5,23 @@ from __future__ import annotations
 from collections import namedtuple
 from functools import partial
 from itertools import combinations
-from typing import TYPE_CHECKING, Any, Callable, Iterator, Literal, Tuple, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Iterator,
+    Literal,
+    Sequence,
+    Tuple,
+    cast,
+)
 
 import numpy
 from joblib import Parallel, delayed  # type: ignore
 from scipy.optimize import root_scalar
 
 from ._tangent_pencil import build_tangent_pencil, target_prime_from_pencil
+from .geometry import unpack_conic
 
 if TYPE_CHECKING:  # pragma: no cover - only for typing
     from ellphi.ellcloud import EllipseCloud
@@ -27,13 +37,12 @@ __all__ = [
 ]
 
 
-def quad_eval(coef: numpy.ndarray, center: Tuple[float, float]) -> float:
-    """Evaluate quadratic form *ax² + 2bxy + cy² + 2dx + 2ey + f*."""
+def quad_eval(coef: numpy.ndarray, center: Sequence[float]) -> float:
+    """Evaluate the quadratic form represented by ``coef`` at ``center``."""
 
-    assert coef.shape == (6,)
-    a, b, c, d, e, f = coef[:6]
-    x, y = center
-    return a * x**2 + 2 * b * x * y + c * y**2 + 2 * d * x + 2 * e * y + f
+    quad, linear, constant = unpack_conic(coef)
+    point = numpy.asarray(center, dtype=float)
+    return float(point @ quad @ point + 2.0 * linear @ point + constant)
 
 
 def pencil(p: numpy.ndarray, q: numpy.ndarray, mu: float) -> numpy.ndarray:
@@ -45,14 +54,13 @@ def pencil(p: numpy.ndarray, q: numpy.ndarray, mu: float) -> numpy.ndarray:
 TangencyResult = namedtuple("TangencyResult", ["t", "point", "mu"])
 
 
-def _center(coef: numpy.ndarray) -> Tuple[float, float]:
-    a, b, c, d, e, _ = coef
-    det = a * c - b**2
-    if det == 0:
+def _center(coef: numpy.ndarray) -> numpy.ndarray:
+    quad, linear, _ = unpack_conic(coef)
+    det = numpy.linalg.det(quad)
+    if det == 0.0:
         raise ZeroDivisionError("Degenerate conic (determinant zero)")
-    x = (b * e - c * d) / det
-    y = (b * d - a * e) / det
-    return (x, y)
+    center = -numpy.linalg.solve(quad, linear)
+    return center
 
 
 def _target(mu: float, p: numpy.ndarray, q: numpy.ndarray) -> float:
@@ -115,8 +123,8 @@ def tangency(
     mu = solve_mu(pcoef, qcoef, method=method, bracket=bracket, x0=x0)
     coef = pencil(pcoef, qcoef, mu)
     point = _center(coef)
-    t = float(numpy.sqrt(quad_eval(coef, point)))
-    return TangencyResult(t, numpy.asarray(point), mu)
+    t = float(numpy.sqrt(quad_eval(pcoef, point)))
+    return TangencyResult(t, numpy.asarray(point, dtype=float), mu)
 
 
 def _indexed_pairs(size: int) -> Iterator[tuple[int, tuple[int, int]]]:

--- a/src/ellphi/_tangent_pencil.py
+++ b/src/ellphi/_tangent_pencil.py
@@ -6,10 +6,12 @@ from dataclasses import dataclass
 
 import numpy as np
 
+from .geometry import unpack_conic
+
 
 @dataclass(frozen=True)
 class TangentPencil:
-    """Geometry of the conic pencil ``(1-μ) p + μ q`` at the solution ``μ``."""
+    """Geometry of the conic pencil ``(1-μ) p + μ q``."""
 
     coef: np.ndarray
     quad: np.ndarray
@@ -20,31 +22,31 @@ class TangentPencil:
 
 
 def quad_matrix(coef: np.ndarray) -> np.ndarray:
-    """Return the 2×2 quadratic-form matrix associated with ``coef``."""
+    """Return the quadratic-form matrix associated with ``coef``."""
 
-    a, b, c = coef[:3]
-    return np.array([[a, b], [b, c]], dtype=float)
+    quad, _, _ = unpack_conic(coef)
+    return quad
 
 
 def linear_vector(coef: np.ndarray) -> np.ndarray:
     """Return the linear-term vector associated with ``coef``."""
 
-    return np.array(coef[3:5], dtype=float)
+    _, linear, _ = unpack_conic(coef)
+    return linear
 
 
 def build_tangent_pencil(mu: float, p: np.ndarray, q: np.ndarray) -> TangentPencil:
     """Construct the tangent pencil for ``μ`` from ``p`` and ``q``."""
 
     coef = (1.0 - mu) * p + mu * q
-    quad = quad_matrix(coef)
-    linear = linear_vector(coef)
-    det = float(quad[0, 0] * quad[1, 1] - quad[0, 1] ** 2)
+    quad, linear, _ = unpack_conic(coef)
+    try:
+        inv_quad = np.linalg.inv(quad)
+    except np.linalg.LinAlgError as exc:  # pragma: no cover - defensive
+        raise ZeroDivisionError("Degenerate conic (determinant zero)") from exc
+    det = float(np.linalg.det(quad))
     if det == 0.0:
         raise ZeroDivisionError("Degenerate conic (determinant zero)")
-    inv_quad = (1.0 / det) * np.array(
-        [[quad[1, 1], -quad[0, 1]], [-quad[0, 1], quad[0, 0]]],
-        dtype=float,
-    )
     center = -inv_quad @ linear
     return TangentPencil(
         coef=coef, quad=quad, linear=linear, det=det, inv_quad=inv_quad, center=center
@@ -63,26 +65,37 @@ def target_prime_from_pencil(
     return float(2.0 * residual @ pencil.inv_quad @ residual)
 
 
+def _quadratic_basis(dim: int) -> np.ndarray:
+    basis = []
+    for i in range(dim):
+        for j in range(i, dim):
+            mat = np.zeros((dim, dim), dtype=float)
+            mat[i, j] = 1.0
+            mat[j, i] = 1.0
+            basis.append(mat)
+    return np.asarray(basis)
+
+
 def center_jacobian(pencil: TangentPencil) -> np.ndarray:
     """Return ``∂x_c/∂r`` where ``r`` are pencil coefficients."""
 
-    jac = np.zeros((6, 2), dtype=float)
-    basis_matrices = (
-        np.array([[1.0, 0.0], [0.0, 0.0]], dtype=float),
-        np.array([[0.0, 1.0], [1.0, 0.0]], dtype=float),
-        np.array([[0.0, 0.0], [0.0, 1.0]], dtype=float),
-    )
-    basis_vectors = (
-        np.array([1.0, 0.0], dtype=float),
-        np.array([0.0, 1.0], dtype=float),
-    )
+    dim = pencil.center.shape[0]
+    quad_basis = _quadratic_basis(dim)
+    num_quad = quad_basis.shape[0]
+    num_coef = num_quad + dim + 1
+    jac = np.zeros((num_coef, dim), dtype=float)
 
-    for idx in range(3):
-        d_quad = basis_matrices[idx]
-        rhs = d_quad @ pencil.center
-        jac[idx] = -(pencil.inv_quad @ rhs)
+    inv_quad = pencil.inv_quad
+    center = pencil.center
 
-    jac[3] = -(pencil.inv_quad @ basis_vectors[0])
-    jac[4] = -(pencil.inv_quad @ basis_vectors[1])
-    # The constant term does not influence the center.
+    for idx, basis in enumerate(quad_basis):
+        rhs = basis @ center
+        jac[idx] = -(inv_quad @ rhs)
+
+    for idx in range(dim):
+        basis_vec = np.zeros(dim, dtype=float)
+        basis_vec[idx] = 1.0
+        jac[num_quad + idx] = -(inv_quad @ basis_vec)
+
+    # Constant term leaves the center unchanged.
     return jac

--- a/src/ellphi/differentiable_solver.py
+++ b/src/ellphi/differentiable_solver.py
@@ -100,8 +100,17 @@ def solve_mu_gradients(
         raise ZeroDivisionError("Derivative with respect to mu is numerically zero")
 
     phi_x = -2.0 * residual
-    xc0, xc1 = pencil.center
-    base = np.array([xc0**2, 2.0 * xc0 * xc1, xc1**2, 2.0 * xc0, 2.0 * xc1, 1.0])
+    center = pencil.center
+    dim = center.shape[0]
+
+    quad_terms = []
+    for i in range(dim):
+        quad_terms.append(center[i] ** 2)
+        for j in range(i + 1, dim):
+            quad_terms.append(2.0 * center[i] * center[j])
+    base = np.concatenate(
+        [np.asarray(quad_terms, dtype=float), 2.0 * center, np.array([1.0])]
+    )
 
     jac_center = center_jacobian(pencil)
     dx_dp = (1.0 - mu) * jac_center

--- a/src/ellphi/ellcloud.py
+++ b/src/ellphi/ellcloud.py
@@ -16,7 +16,7 @@ import numpy
 import matplotlib.pyplot as plt
 from scipy.spatial.distance import squareform, pdist
 
-from .geometry import axes_from_cov, coef_from_cov
+from .geometry import axes_from_cov, coef_from_cov, infer_dim_from_coef_length
 from .solver import pdist_tangency
 
 __all__ = ["ellipse_cloud", "EllipseCloud", "LocalCov"]
@@ -26,16 +26,26 @@ __all__ = ["ellipse_cloud", "EllipseCloud", "LocalCov"]
 class EllipseCloud:
     """Container for an ellipse cloud with convenience methods."""
 
-    coef: numpy.ndarray  # (N, 6)
-    mean: numpy.ndarray  # (N, 2)
-    cov: numpy.ndarray  # (N, 2, 2)
+    coef: numpy.ndarray  # (N, m)
+    mean: numpy.ndarray  # (N, n)
+    cov: numpy.ndarray  # (N, n, n)
     k: int
     nbd: numpy.ndarray  # (N, k)  k-NN indices
     n: int = field(init=False)
+    n_dim: int = field(init=False)
+    coef_length: int = field(init=False)
 
     # ---- automatic field from coef.shape ---------------------------------
     def __post_init__(self):
         self.n = self.coef.shape[0]
+        self.coef_length = self.coef.shape[1]
+        self.n_dim = infer_dim_from_coef_length(self.coef_length)
+        if self.mean.shape != (self.n, self.n_dim):
+            raise ValueError("Mean array shape inconsistent with coefficients")
+        if self.cov.shape != (self.n, self.n_dim, self.n_dim):
+            raise ValueError("Covariance array shape inconsistent with coefficients")
+        if self.nbd.shape[0] != self.n:
+            raise ValueError("Neighbourhood array must align with coefficient count")
 
     # ---- basic Python protocol ------------------------------------------
     def __len__(self) -> int:
@@ -45,7 +55,7 @@ class EllipseCloud:
         return iter(self.coef)
 
     def __getitem__(self, idx) -> numpy.ndarray:
-        """Return the conic coefficient array (6,) for a single ellipse."""
+        """Return the conic coefficient array for a single ellipsoid."""
         return self.coef[idx]
 
     def __str__(self):
@@ -79,6 +89,11 @@ class EllipseCloud:
             Existing axes; if None, creates a new figure.
         """
         from .visualization import ellipse_patch
+
+        if self.n_dim != 2:
+            raise NotImplementedError(
+                "Plotting is currently supported only for 2D ellipses"
+            )
 
         if ax is None:
             fig, ax = plt.subplots()
@@ -137,8 +152,8 @@ class EllipseCloud:
         """
         Parameters
         ----------
-        X : ndarray, shape (N, 2)
-            Input point cloud (x, y)
+        X : ndarray, shape (N, d)
+            Input point cloud in ``d`` spatial dimensions.
         method : str
             Conversion algorithm. The supported method is "local_cov".
         rescaling : str
@@ -173,6 +188,10 @@ class EllipseCloud:
         Apply rescaling to all the ellipses.
         The supported method is "median" or "average".
         """
+        if self.n_dim != 2:
+            raise NotImplementedError(
+                "Rescaling is currently defined only for 2D ellipses"
+            )
         eigvals = numpy.linalg.eigvalsh(self.cov)
         scales = numpy.sqrt(eigvals)
         if method == "median":
@@ -208,8 +227,8 @@ class LocalCov:
         """
         Parameters
         ----------
-        X : ndarray, shape (N, 2)
-            Input point cloud (x, y)
+        X : ndarray, shape (N, d)
+            Input point cloud.
 
         Returns
         -------
@@ -225,6 +244,9 @@ class LocalCov:
                 "Local covariance requires at least two neighbours (k >= 2); "
                 f"got k={k}."
             )
+        if X.ndim != 2:
+            raise ValueError("Input point cloud must be a 2D array (N, d)")
+
         d = squareform(pdist(X))  # Euclidean distance matrix
         neighbour_indices = numpy.argsort(d, axis=1)[:, :k]
         sorted_subsets = numpy.sort(neighbour_indices, axis=1)

--- a/src/ellphi/geometry.py
+++ b/src/ellphi/geometry.py
@@ -1,25 +1,82 @@
-"""
-ellphi.geometry  –  geometric helpers for ellipse cloud
-=======================================================
-
-Key API (all return NumPy float64):
-
-- unit_vector(theta)
-- axes_from_cov(cov, scale=1.0)
-- coef_from_axes(X, r0, r1, theta)  # centre+axes → (6,)
-- coef_from_cov(X, cov, scale=1.0)  # centre+cov → (6,)
-"""
+"""Geometric helpers for ellipsoids in arbitrary dimensions."""
 
 from __future__ import annotations
 
 import numpy
+from numpy.typing import ArrayLike
 
 __all__ = [
     "unit_vector",
     "axes_from_cov",
     "coef_from_axes",
     "coef_from_cov",
+    "pack_conic",
+    "unpack_conic",
+    "infer_dim_from_coef_length",
 ]
+
+
+def infer_dim_from_coef_length(length: int) -> int:
+    """Return the spatial dimension encoded by a flattened conic."""
+
+    if length < 6:
+        raise ValueError("Coefficient array must have length at least 6 for n ≥ 2")
+    disc = 1 + 8 * length
+    root = int(numpy.sqrt(disc))
+    if root * root != disc:
+        raise ValueError("Coefficient length does not match any ellipsoid dimension")
+    dim = (root - 3) // 2
+    if (dim + 1) * (dim + 2) // 2 != length:
+        raise ValueError("Coefficient length does not correspond to a valid ellipsoid")
+    return dim
+
+
+def _triangular_indices(dim: int) -> tuple[numpy.ndarray, numpy.ndarray]:
+    return numpy.triu_indices(dim)
+
+
+def pack_conic(
+    quad: numpy.ndarray,
+    linear: numpy.ndarray,
+    constant: ArrayLike,
+) -> numpy.ndarray:
+    """Pack quadratic data ``(A, b, c)`` into a flattened coefficient vector."""
+
+    quad = numpy.asarray(quad, dtype=float)
+    linear = numpy.asarray(linear, dtype=float)
+    constant = numpy.asarray(constant, dtype=float)
+
+    if quad.ndim < 2 or quad.shape[-1] != quad.shape[-2]:
+        raise ValueError("Quadratic term must be a square matrix")
+    if linear.shape[-1] != quad.shape[-1]:
+        raise ValueError("Linear term dimension must match quadratic term")
+
+    dim = quad.shape[-1]
+    tri_upper = _triangular_indices(dim)
+    quad_flat = quad[..., tri_upper[0], tri_upper[1]]
+    linear_flat = linear
+    constant_flat = numpy.expand_dims(constant, axis=-1)
+    return numpy.concatenate([quad_flat, linear_flat, constant_flat], axis=-1)
+
+
+def unpack_conic(coef: numpy.ndarray) -> tuple[numpy.ndarray, numpy.ndarray, float]:
+    """Return ``(A, b, c)`` from a flattened conic coefficient vector."""
+
+    coef = numpy.asarray(coef, dtype=float)
+    if coef.ndim != 1:
+        raise ValueError("Expected a one-dimensional coefficient array")
+
+    dim = infer_dim_from_coef_length(coef.shape[0])
+    tri_len = dim * (dim + 1) // 2
+    quad_flat = coef[:tri_len]
+    linear = coef[tri_len : tri_len + dim]
+    constant = float(coef[-1])
+
+    quad = numpy.zeros((dim, dim), dtype=float)
+    tri_upper = _triangular_indices(dim)
+    quad[tri_upper] = quad_flat
+    quad[(tri_upper[1], tri_upper[0])] = quad_flat
+    return quad, linear, constant
 
 
 # ------------------------------------------------------------------
@@ -65,16 +122,9 @@ def _coef_core(X, r0, r1, cos, sin):
 
 
 def _inv_broadcast(cov: numpy.ndarray) -> numpy.ndarray:
-    """Vectorized inverse of a batch of 2x2 matrices."""
-    a, b, c, d = cov[:, 0, 0], cov[:, 0, 1], cov[:, 1, 0], cov[:, 1, 1]
-    det = a * d - b * c
-    inv_det = 1.0 / det
-    inv_cov = numpy.empty_like(cov)
-    inv_cov[:, 0, 0] = d * inv_det
-    inv_cov[:, 0, 1] = -b * inv_det
-    inv_cov[:, 1, 0] = -c * inv_det
-    inv_cov[:, 1, 1] = a * inv_det
-    return inv_cov
+    """Vectorized inverse of a batch of SPD matrices."""
+
+    return numpy.linalg.inv(cov)
 
 
 def coef_from_axes(X: float, r0: float, r1: float, theta: float) -> numpy.ndarray:
@@ -89,24 +139,18 @@ def coef_from_cov(
     *,
     scale: float = 1.0,
 ) -> numpy.ndarray:
-    """Centre + covariance → conic coefficients."""
-    X = numpy.array(X)
-    if len(X.shape) <= 1:
-        X = X[None, :]  # Extend if single observation
-    if len(cov.shape) <= 2:
-        cov = cov[None, :, :]  # Extend if single observation
-    centers = X[:, :, None]
-    matrices = _inv_broadcast(cov) / scale**2
-    coef_b = -matrices @ centers
-    coef_c = centers.transpose(0, 2, 1) @ matrices @ centers
-    return numpy.stack(
-        [
-            matrices[:, 0, 0],
-            matrices[:, 0, 1],
-            matrices[:, 1, 1],
-            coef_b[:, 0].ravel(),
-            coef_b[:, 1].ravel(),
-            coef_c.ravel(),
-        ],
-        axis=-1,
-    )
+    """Centre + covariance → conic coefficients (any dimension)."""
+
+    X = numpy.asarray(X, dtype=float)
+    cov = numpy.asarray(cov, dtype=float)
+
+    if X.ndim == 1:
+        X = X[None, :]
+    if cov.ndim == 2:
+        cov = cov[None, :, :]
+
+    inv_cov = _inv_broadcast(cov) / scale**2
+    centers = X[..., None]
+    linear = -(inv_cov @ centers)[..., 0]
+    constant = numpy.einsum("...i,...ij,...j->...", X, inv_cov, X)
+    return pack_conic(inv_cov, linear, constant)

--- a/src/ellphi/solver.py
+++ b/src/ellphi/solver.py
@@ -8,6 +8,7 @@ import numpy
 
 from . import _solver_python as _py
 from . import _tangency_cpp as _cpp
+from .geometry import infer_dim_from_coef_length
 
 __all__ = [
     "quad_eval",
@@ -50,12 +51,16 @@ def has_cpp_backend() -> bool:
 def _extract_coef_array(ellcloud: Iterable[numpy.ndarray]) -> numpy.ndarray:
     coef = getattr(ellcloud, "coef", ellcloud)
     array = numpy.asarray(coef, dtype=float)
-    if array.ndim != 2 or array.shape[1] != 6:
-        raise ValueError("Expected ellipse coefficients with shape (n, 6)")
+    if array.ndim != 2:
+        raise ValueError("Expected ellipse coefficients with shape (n, m)")
+    try:
+        infer_dim_from_coef_length(array.shape[1])
+    except ValueError as exc:  # pragma: no cover - sanity check
+        raise ValueError("Invalid coefficient length for ellipsoids") from exc
     return array
 
 
-def _should_use_cpp(backend: str) -> bool:
+def _should_use_cpp(backend: str, *, dim: int | None = None) -> bool:
     if backend not in _BACKEND_NAMES:
         raise ValueError(
             f"Unknown backend '{backend}'. Expected one of {', '.join(_BACKEND_NAMES)}"
@@ -63,8 +68,12 @@ def _should_use_cpp(backend: str) -> bool:
     if backend == "cpp":
         if not has_cpp_backend():
             raise RuntimeError("C++ backend requested but not available")
+        if dim is not None and dim != 2:
+            raise RuntimeError("C++ backend currently supports only 2D ellipses")
         return True
     if backend == "auto":
+        if dim is not None and dim != 2:
+            return False
         return has_cpp_backend()
     return False
 
@@ -87,7 +96,8 @@ def tangency(
     """Return (t, point, μ) at which two ellipses are tangent."""
 
     method_literal = _normalize_method(method)
-    if _should_use_cpp(backend):
+    dim = infer_dim_from_coef_length(len(pcoef))
+    if _should_use_cpp(backend, dim=dim):
         return _cpp.tangency(
             pcoef,
             qcoef,
@@ -126,8 +136,9 @@ def pdist_tangency(
         Backend used for the tangency computation.
     """
 
-    if _should_use_cpp(backend):
-        coef = _extract_coef_array(ellcloud)
+    coef = _extract_coef_array(ellcloud)
+    dim = infer_dim_from_coef_length(coef.shape[1])
+    if _should_use_cpp(backend, dim=dim):
         return _cpp.pdist_tangency(coef)
     if parallel:
         return _pdist_tangency_parallel(ellcloud, n_jobs=n_jobs)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,7 +1,6 @@
 """Factories shared across unit tests."""
 
 from __future__ import annotations
-
 import numpy as np
 from numpy.typing import NDArray
 
@@ -11,31 +10,43 @@ from ellphi.geometry import coef_from_cov
 
 def rotation_matrix(angle: float) -> NDArray[np.float64]:
     """Return a 2D rotation matrix for the given angle in radians."""
+
     cos, sin = np.cos(angle), np.sin(angle)
     return np.array([[cos, -sin], [sin, cos]], dtype=float)
 
 
-def random_covariance(rng: np.random.Generator) -> NDArray[np.float64]:
-    """Draw a random, symmetric positive-definite 2×2 covariance matrix."""
-    axes = rng.uniform(1.0, 6.0, size=2)
-    rot = rotation_matrix(rng.uniform(0.0, np.pi))
+def random_covariance(rng: np.random.Generator, dim: int = 2) -> NDArray[np.float64]:
+    """Draw a random, symmetric positive-definite covariance matrix."""
+
+    axes = rng.uniform(1.0, 6.0, size=dim)
+    if dim == 2:
+        rot = rotation_matrix(rng.uniform(0.0, np.pi))
+    else:
+        basis = rng.normal(size=(dim, dim))
+        rot, _ = np.linalg.qr(basis)
     return rot @ np.diag(axes) @ rot.T
 
 
 def random_coef_pair(
     rng: np.random.Generator,
+    *,
+    dim: int = 2,
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Return two random ellipse coefficients using consistent sampling."""
-    means = rng.uniform(-50.0, 50.0, size=(2, 2))
-    covs = np.stack([random_covariance(rng) for _ in range(2)])
+    """Return two random ellipsoid coefficients using consistent sampling."""
+
+    means = rng.uniform(-50.0, 50.0, size=(2, dim))
+    covs = np.stack([random_covariance(rng, dim=dim) for _ in range(2)])
     coefs = coef_from_cov(means, covs)
     return coefs[0], coefs[1]
 
 
-def random_cloud(rng: np.random.Generator, n_ellipses: int) -> EllipseCloud:
-    """Construct an ``EllipseCloud`` populated with random ellipses."""
-    means = rng.uniform(-50.0, 50.0, size=(n_ellipses, 2))
-    covs = np.stack([random_covariance(rng) for _ in range(n_ellipses)])
+def random_cloud(
+    rng: np.random.Generator, n_ellipses: int, *, dim: int = 2
+) -> EllipseCloud:
+    """Construct an ``EllipseCloud`` populated with random ellipsoids."""
+
+    means = rng.uniform(-50.0, 50.0, size=(n_ellipses, dim))
+    covs = np.stack([random_covariance(rng, dim=dim) for _ in range(n_ellipses)])
     coefs = coef_from_cov(means, covs)
     dummy_nbd = np.empty((n_ellipses, 0), dtype=int)
     return EllipseCloud(coef=coefs, mean=means, cov=covs, k=0, nbd=dummy_nbd)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -3,7 +3,7 @@ from typing import Any, cast
 
 import numpy as np
 import pytest
-from ellphi import coef_from_axes, tangency
+from ellphi import coef_from_axes, coef_from_cov, tangency
 from ellphi.solver import quad_eval
 from tests.factories import random_coef_pair, rotation_matrix
 
@@ -195,6 +195,31 @@ def test_circle_tangency_matches_closed_form(case: CircleCase, solver_backend):
     assert res.point.tolist() == pytest.approx(
         expected_point.tolist(), rel=1e-9, abs=1e-12
     )
+
+
+def test_three_dimensional_spheres_match_closed_form():
+    center_p = np.array([0.0, 0.0, 0.0])
+    center_q = np.array([4.0, 1.0, -2.0])
+    radius_p = 1.5
+    radius_q = 0.75
+
+    cov_p = np.eye(3) * radius_p**2
+    cov_q = np.eye(3) * radius_q**2
+
+    pcoef = coef_from_cov(center_p, cov_p)[0]
+    qcoef = coef_from_cov(center_q, cov_q)[0]
+
+    res = tangency(pcoef, qcoef)
+
+    distance = np.linalg.norm(center_q - center_p)
+    expected_t = distance / (radius_p + radius_q)
+    expected_mu = radius_q / (radius_p + radius_q)
+    direction = (center_q - center_p) / distance
+    expected_point = center_p + direction * (radius_p * expected_t)
+
+    assert res.t == pytest.approx(expected_t, rel=1e-9)
+    np.testing.assert_allclose(res.point, expected_point, rtol=1e-9, atol=1e-9)
+    assert res.mu == pytest.approx(expected_mu, rel=1e-9)
 
 
 # -----------------------------------------------------------------------------

--- a/tests/test_differentiable_solver.py
+++ b/tests/test_differentiable_solver.py
@@ -31,13 +31,16 @@ def solve_mu_forward_diff(
     return d_mu_dp, d_mu_dq
 
 
-def test_numerical_differentiation(rng):
+@pytest.mark.parametrize("dim", [2, 3])
+def test_numerical_differentiation(rng, dim):
     """The numerical Jacobian matches a forward-difference baseline."""
-    p, q = random_coef_pair(rng)
+
+    p, q = random_coef_pair(rng, dim=dim)
 
     d_mu_dp, d_mu_dq = solve_mu_numerical_diff(p, q)
-    assert d_mu_dp.shape == (6,), f"Expected shape (6,), but got {d_mu_dp.shape}"
-    assert d_mu_dq.shape == (6,), f"Expected shape (6,), but got {d_mu_dq.shape}"
+    expected_len = p.shape[0]
+    assert d_mu_dp.shape == (expected_len,)
+    assert d_mu_dq.shape == (expected_len,)
 
     d_mu_dp_forward, d_mu_dq_forward = solve_mu_forward_diff(p, q)
     np.testing.assert_allclose(
@@ -56,11 +59,12 @@ def test_numerical_differentiation(rng):
     )
 
 
-def test_analytic_gradients_match_central_difference(rng):
+@pytest.mark.parametrize("dim", [2, 3])
+def test_analytic_gradients_match_central_difference(rng, dim):
     """The analytic gradients agree with central differences."""
 
     for _ in range(5):
-        p, q = random_coef_pair(rng)
+        p, q = random_coef_pair(rng, dim=dim)
         mu, d_mu_dp, d_mu_dq = solve_mu_gradients(p, q)
         d_mu_dp_num, d_mu_dq_num = solve_mu_numerical_diff(p, q)
 

--- a/tests/test_ellcloud.py
+++ b/tests/test_ellcloud.py
@@ -62,3 +62,21 @@ def test_local_cov_merges_identical_neighbourhoods():
     assert ellcloud.nbd.shape == (2, 3)
     assert np.array_equal(ellcloud.nbd, np.array([[0, 1, 2], [3, 4, 5]]))
     assert np.array_equal(ellcloud.nbd, np.sort(ellcloud.nbd, axis=1))
+
+
+def test_local_cov_supports_three_dimensions():
+    X = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+
+    ellcloud = EllipseCloud.from_local_cov(X, k=4)
+
+    assert ellcloud.n_dim == 3
+    assert ellcloud.coef.shape[1] == (ellcloud.n_dim + 1) * (ellcloud.n_dim + 2) // 2
+    assert ellcloud.mean.shape[1] == 3
+    assert ellcloud.cov.shape[1:] == (3, 3)

--- a/tests/test_ellcloud_rescale.py
+++ b/tests/test_ellcloud_rescale.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import numpy as np
+import pytest
 
 from .factories import random_cloud
 
@@ -21,3 +22,11 @@ def test_rescale_returns_float_and_updates_arrays():
     assert isinstance(scale, float)
     np.testing.assert_allclose(cloud.cov, cov_before / scale**2)
     np.testing.assert_allclose(cloud.coef, coef_before * scale**2)
+
+
+def test_rescale_not_implemented_for_three_dimensions():
+    rng = np.random.default_rng(2025)
+    cloud = random_cloud(rng, n_ellipses=3, dim=3)
+
+    with pytest.raises(NotImplementedError):
+        cloud.rescale()

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -6,6 +6,9 @@ from ellphi.geometry import (
     axes_from_cov,
     coef_from_axes,
     coef_from_cov,
+    infer_dim_from_coef_length,
+    pack_conic,
+    unpack_conic,
 )
 
 
@@ -46,3 +49,39 @@ def test_coef_from_cov():
     coef1 = coef_from_axes([x0, y0], r1, r2, th)
     coef2 = coef_from_cov([x0, y0], cov)
     assert np.allclose(coef1, coef2, rtol=1e-12, atol=1e-12)
+
+
+def test_pack_unpack_roundtrip_three_dimensional():
+    quad = np.array(
+        [[4.0, 1.0, 0.2], [1.0, 3.5, -0.4], [0.2, -0.4, 2.2]],
+        dtype=float,
+    )
+    linear = np.array([-1.0, 0.5, 2.0], dtype=float)
+    constant = 0.7
+    coef = pack_conic(quad, linear, constant)
+    quad_rec, linear_rec, constant_rec = unpack_conic(coef)
+    np.testing.assert_allclose(quad_rec, quad)
+    np.testing.assert_allclose(linear_rec, linear)
+    assert constant_rec == pytest.approx(constant)
+
+
+@pytest.mark.parametrize("length, expected", [(6, 2), (10, 3)])
+def test_infer_dim_from_coef_length(length, expected):
+    assert infer_dim_from_coef_length(length) == expected
+
+
+def test_coef_from_cov_three_dimensional():
+    rng = np.random.default_rng(0)
+    center = rng.normal(size=3)
+    basis = rng.normal(size=(3, 3))
+    rot, _ = np.linalg.qr(basis)
+    eigenvalues = rng.uniform(0.5, 2.0, size=3)
+    cov = rot @ np.diag(eigenvalues**2) @ rot.T
+
+    coef = coef_from_cov(center, cov)[0]
+    quad, linear, constant = unpack_conic(coef)
+
+    inv_cov = np.linalg.inv(cov)
+    np.testing.assert_allclose(quad, inv_cov)
+    np.testing.assert_allclose(linear, -inv_cov @ center)
+    assert constant == pytest.approx(center @ inv_cov @ center)

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -1,4 +1,5 @@
 import numpy as np
+import numpy as np
 import pytest
 
 from ellphi.solver import pdist_tangency
@@ -27,3 +28,11 @@ def test_pdist_tangency_consistency(ellipse_cloud, solver_backend):
         parallel_result,
         err_msg="Serial and parallel results are not close enough.",
     )
+
+
+def test_pdist_tangency_three_dimensional_python_backend(rng):
+    cloud = random_cloud(rng, n_ellipses=8, dim=3)
+    result = pdist_tangency(cloud, parallel=False, backend="python")
+    expected_length = cloud.n * (cloud.n - 1) // 2
+    assert result.shape == (expected_length,)
+    assert np.all(result >= 0.0)

--- a/tests/test_tangent_pencil.py
+++ b/tests/test_tangent_pencil.py
@@ -82,12 +82,6 @@ CIRCLE_CASES = [
 ]
 
 
-def _as_point(center: np.ndarray) -> tuple[float, float]:
-    """Return the center as a tuple compatible with `quad_eval`."""
-
-    return (float(center[0]), float(center[1]))
-
-
 @pytest.mark.parametrize("case", CIRCLE_CASES)
 def test_circle_center_and_gradients_match_hand_solution(case: CircleTangencyCase):
     """Circle cases exercise the full Lagrange conditions analytically."""
@@ -104,9 +98,8 @@ def test_circle_center_and_gradients_match_hand_solution(case: CircleTangencyCas
         pencil.center, case.contact_point, rtol=1e-12, atol=1e-12
     )
 
-    point = _as_point(pencil.center)
-    val_p = quad_eval(p, point)
-    val_q = quad_eval(q, point)
+    val_p = quad_eval(p, pencil.center)
+    val_q = quad_eval(q, pencil.center)
     assert val_p == pytest.approx(val_q, rel=1e-12, abs=1e-12)
 
     grad_combo = pencil.quad @ pencil.center + pencil.linear
@@ -168,16 +161,17 @@ def test_circle_center_jacobian_matches_manual_formula(case: CircleTangencyCase)
     np.testing.assert_allclose(jac, expected, rtol=1e-12, atol=1e-12)
 
 
-def test_center_jacobian_matches_finite_difference(rng: np.random.Generator):
+@pytest.mark.parametrize("dim", [2, 3])
+def test_center_jacobian_matches_finite_difference(rng: np.random.Generator, dim: int):
     """`center_jacobian` matches a central-difference approximation."""
 
     for _ in range(5):
-        p, q = random_coef_pair(rng)
+        p, q = random_coef_pair(rng, dim=dim)
         mu = solve_mu(p, q)
         pencil = build_tangent_pencil(mu, p, q)
         jac = center_jacobian(pencil)
 
-        for idx in range(6):
+        for idx in range(pencil.coef.shape[0]):
             step = 1e-6
             coef_plus = pencil.coef.copy()
             coef_minus = pencil.coef.copy()
@@ -198,15 +192,18 @@ def test_center_jacobian_matches_finite_difference(rng: np.random.Generator):
 
 def _target_value(mu: float, p: np.ndarray, q: np.ndarray) -> float:
     pencil = build_tangent_pencil(mu, p, q)
-    center = _as_point(pencil.center)
+    center = pencil.center
     return float(quad_eval(p, center) - quad_eval(q, center))
 
 
-def test_target_prime_chain_rule_matches_closed_form(rng: np.random.Generator):
+@pytest.mark.parametrize("dim", [2, 3])
+def test_target_prime_chain_rule_matches_closed_form(
+    rng: np.random.Generator, dim: int
+):
     """Chain rule using `center_jacobian` reproduces the cached derivative."""
 
     for _ in range(5):
-        p, q = random_coef_pair(rng)
+        p, q = random_coef_pair(rng, dim=dim)
         mu = solve_mu(p, q)
         pencil = build_tangent_pencil(mu, p, q)
         jac = center_jacobian(pencil)
@@ -224,11 +221,12 @@ def test_target_prime_chain_rule_matches_closed_form(rng: np.random.Generator):
         )
 
 
-def test_target_prime_matches_finite_difference(rng: np.random.Generator):
+@pytest.mark.parametrize("dim", [2, 3])
+def test_target_prime_matches_finite_difference(rng: np.random.Generator, dim: int):
     """`target_prime_from_pencil` matches a finite-difference baseline."""
 
     for _ in range(5):
-        p, q = random_coef_pair(rng)
+        p, q = random_coef_pair(rng, dim=dim)
         mu = solve_mu(p, q)
         pencil = build_tangent_pencil(mu, p, q)
 
@@ -244,20 +242,20 @@ def test_target_prime_matches_finite_difference(rng: np.random.Generator):
         assert deriv_exact == pytest.approx(deriv_fd, rel=1e-8, abs=1e-8)
 
 
-def test_lagrange_conditions_hold_for_random_pairs(rng: np.random.Generator):
+@pytest.mark.parametrize("dim", [2, 3])
+def test_lagrange_conditions_hold_for_random_pairs(rng: np.random.Generator, dim: int):
     """Random ellipses satisfy the Lagrange multiplier conditions."""
 
     for _ in range(5):
-        p, q = random_coef_pair(rng)
+        p, q = random_coef_pair(rng, dim=dim)
         mu = solve_mu(p, q)
         pencil = build_tangent_pencil(mu, p, q)
         center = pencil.center
 
         grad_combo = pencil.quad @ center + pencil.linear
-        np.testing.assert_allclose(grad_combo, np.zeros(2), atol=1e-10)
+        np.testing.assert_allclose(grad_combo, np.zeros_like(center), atol=1e-10)
 
-        center_point = _as_point(center)
-        val_diff = quad_eval(p, center_point) - quad_eval(q, center_point)
+        val_diff = quad_eval(p, center) - quad_eval(q, center)
         assert val_diff == pytest.approx(0.0, abs=1e-10)
 
         grad_p = 2.0 * (quad_matrix(p) @ center + linear_vector(p))
@@ -266,8 +264,9 @@ def test_lagrange_conditions_hold_for_random_pairs(rng: np.random.Generator):
         residual = (1.0 - mu) * grad_p + mu * grad_q
         np.testing.assert_allclose(residual, np.zeros_like(residual), atol=1e-10)
 
-        cross = grad_p[0] * grad_q[1] - grad_p[1] * grad_q[0]
-        assert cross == pytest.approx(0.0, abs=1e-10)
+        dot = float(np.dot(grad_p, grad_q))
+        norms = float(np.linalg.norm(grad_p) * np.linalg.norm(grad_q))
+        assert abs(abs(dot) - norms) <= 1e-8
 
 
 def test_saddle_point_behaviour(rng: np.random.Generator):


### PR DESCRIPTION
## Summary
- extend the geometry helpers with utilities to pack/unpack quadratic data and infer the dimensionality of coefficient arrays, and generalise the Python tangency solver to operate on n-dimensional ellipsoids
- update the solver dispatch and EllipseCloud/LocalCov APIs to validate coefficient lengths, expose the ellipsoid dimension, and guard 2D-only features such as plotting and rescaling
- refresh the differentiable solver and test factories for arbitrary dimensions and add new 3D sphere/ellipsoid regression tests

## Testing
- poetry run pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d8ffe3830832399a5e800b4ac3561)