### PR TITLE
Add n-dimensional support for ellipsoid tangency

### DIFF
--- a/src/ellphi/_solver_python.py
+++ b/src/ellphi/_solver_python.py
@@ -12,6 +12,7 @@ from joblib import Parallel, delayed  # type: ignore
 from scipy.optimize import root_scalar
 
 from ._tangent_pencil import build_tangent_pencil, target_prime_from_pencil
+from .geometry import unpack_conic
 
 if TYPE_CHECKING:  # pragma: no cover - only for typing
     from ellphi.ellcloud import EllipseCloud
@@ -27,13 +28,12 @@ __all__ = [
 ]
 
 
-def quad_eval(coef: numpy.ndarray, center: Tuple[float, float]) -> float:
-    """Evaluate quadratic form *ax² + 2bxy + cy² + 2dx + 2ey + f*."""
+def quad_eval(coef: numpy.ndarray, center: Tuple[float, ...]) -> float:
+    """Evaluate ``xᵀ A x + 2 bᵀ x + c`` at ``center``."""
 
-    assert coef.shape == (6,)
-    a, b, c, d, e, f = coef[:6]
-    x, y = center
-    return a * x**2 + 2 * b * x * y + c * y**2 + 2 * d * x + 2 * e * y + f
+    A, b, c = unpack_conic(coef)
+    x = numpy.asarray(center, dtype=float)
+    return float(x @ A @ x + 2.0 * b @ x + c)
 
 
 def pencil(p: numpy.ndarray, q: numpy.ndarray, mu: float) -> numpy.ndarray:
@@ -45,14 +45,12 @@ def pencil(p: numpy.ndarray, q: numpy.ndarray, mu: float) -> numpy.ndarray:
 TangencyResult = namedtuple("TangencyResult", ["t", "point", "mu"])
 
 
-def _center(coef: numpy.ndarray) -> Tuple[float, float]:
-    a, b, c, d, e, _ = coef
-    det = a * c - b**2
-    if det == 0:
+def _center(coef: numpy.ndarray) -> numpy.ndarray:
+    A, b, _ = unpack_conic(coef)
+    det = numpy.linalg.det(A)
+    if numpy.isclose(det, 0.0):
         raise ZeroDivisionError("Degenerate conic (determinant zero)")
-    x = (b * e - c * d) / det
-    y = (b * d - a * e) / det
-    return (x, y)
+    return -numpy.linalg.solve(A, b)
 
 
 def _target(mu: float, p: numpy.ndarray, q: numpy.ndarray) -> float:
@@ -115,8 +113,8 @@ def tangency(
     mu = solve_mu(pcoef, qcoef, method=method, bracket=bracket, x0=x0)
     coef = pencil(pcoef, qcoef, mu)
     point = _center(coef)
-    t = float(numpy.sqrt(quad_eval(coef, point)))
-    return TangencyResult(t, numpy.asarray(point), mu)
+    t = float(numpy.sqrt(quad_eval(coef, tuple(point))))
+    return TangencyResult(t, point, mu)
 
 
 def _indexed_pairs(size: int) -> Iterator[tuple[int, tuple[int, int]]]:

--- a/src/ellphi/_tangent_pencil.py
+++ b/src/ellphi/_tangent_pencil.py
@@ -6,6 +6,8 @@ from dataclasses import dataclass
 
 import numpy as np
 
+from .geometry import unpack_conic
+
 
 @dataclass(frozen=True)
 class TangentPencil:
@@ -20,16 +22,17 @@ class TangentPencil:
 
 
 def quad_matrix(coef: np.ndarray) -> np.ndarray:
-    """Return the 2×2 quadratic-form matrix associated with ``coef``."""
+    """Return the quadratic-form matrix associated with ``coef``."""
 
-    a, b, c = coef[:3]
-    return np.array([[a, b], [b, c]], dtype=float)
+    A, _, _ = unpack_conic(coef)
+    return A
 
 
 def linear_vector(coef: np.ndarray) -> np.ndarray:
     """Return the linear-term vector associated with ``coef``."""
 
-    return np.array(coef[3:5], dtype=float)
+    _, b, _ = unpack_conic(coef)
+    return b
 
 
 def build_tangent_pencil(mu: float, p: np.ndarray, q: np.ndarray) -> TangentPencil:
@@ -38,13 +41,10 @@ def build_tangent_pencil(mu: float, p: np.ndarray, q: np.ndarray) -> TangentPenc
     coef = (1.0 - mu) * p + mu * q
     quad = quad_matrix(coef)
     linear = linear_vector(coef)
-    det = float(quad[0, 0] * quad[1, 1] - quad[0, 1] ** 2)
-    if det == 0.0:
+    det = float(np.linalg.det(quad))
+    if np.isclose(det, 0.0):
         raise ZeroDivisionError("Degenerate conic (determinant zero)")
-    inv_quad = (1.0 / det) * np.array(
-        [[quad[1, 1], -quad[0, 1]], [-quad[0, 1], quad[0, 0]]],
-        dtype=float,
-    )
+    inv_quad = np.linalg.inv(quad)
     center = -inv_quad @ linear
     return TangentPencil(
         coef=coef, quad=quad, linear=linear, det=det, inv_quad=inv_quad, center=center
@@ -66,23 +66,20 @@ def target_prime_from_pencil(
 def center_jacobian(pencil: TangentPencil) -> np.ndarray:
     """Return ``∂x_c/∂r`` where ``r`` are pencil coefficients."""
 
-    jac = np.zeros((6, 2), dtype=float)
-    basis_matrices = (
-        np.array([[1.0, 0.0], [0.0, 0.0]], dtype=float),
-        np.array([[0.0, 1.0], [1.0, 0.0]], dtype=float),
-        np.array([[0.0, 0.0], [0.0, 1.0]], dtype=float),
-    )
-    basis_vectors = (
-        np.array([1.0, 0.0], dtype=float),
-        np.array([0.0, 1.0], dtype=float),
-    )
+    dim = pencil.quad.shape[0]
+    tri_i, tri_j = np.triu_indices(dim)
+    tri_count = len(tri_i)
+    total = (dim + 1) * (dim + 2) // 2
+    jac = np.zeros((total, dim), dtype=float)
 
-    for idx in range(3):
-        d_quad = basis_matrices[idx]
-        rhs = d_quad @ pencil.center
+    for idx, (i, j) in enumerate(zip(tri_i, tri_j)):
+        basis = np.zeros_like(pencil.quad)
+        basis[i, j] = 1.0
+        if i != j:
+            basis[j, i] = 1.0
+        rhs = basis @ pencil.center
         jac[idx] = -(pencil.inv_quad @ rhs)
 
-    jac[3] = -(pencil.inv_quad @ basis_vectors[0])
-    jac[4] = -(pencil.inv_quad @ basis_vectors[1])
-    # The constant term does not influence the center.
+    jac[tri_count : tri_count + dim] = -pencil.inv_quad
+    # The final row corresponds to the constant term which has zero derivative.
     return jac

--- a/src/ellphi/differentiable_solver.py
+++ b/src/ellphi/differentiable_solver.py
@@ -100,8 +100,16 @@ def solve_mu_gradients(
         raise ZeroDivisionError("Derivative with respect to mu is numerically zero")
 
     phi_x = -2.0 * residual
-    xc0, xc1 = pencil.center
-    base = np.array([xc0**2, 2.0 * xc0 * xc1, xc1**2, 2.0 * xc0, 2.0 * xc1, 1.0])
+    center = pencil.center
+    dim = center.size
+    tri_i, tri_j = np.triu_indices(dim)
+    quad_grad = np.where(
+        tri_i == tri_j,
+        center[tri_i] ** 2,
+        2.0 * center[tri_i] * center[tri_j],
+    )
+    linear_grad = 2.0 * center
+    base = np.concatenate([quad_grad, linear_grad, np.array([1.0])])
 
     jac_center = center_jacobian(pencil)
     dx_dp = (1.0 - mu) * jac_center

--- a/src/ellphi/ellcloud.py
+++ b/src/ellphi/ellcloud.py
@@ -16,7 +16,7 @@ import numpy
 import matplotlib.pyplot as plt
 from scipy.spatial.distance import squareform, pdist
 
-from .geometry import axes_from_cov, coef_from_cov
+from .geometry import axes_from_cov, coef_from_cov, infer_dim_from_coef_length
 from .solver import pdist_tangency
 
 __all__ = ["ellipse_cloud", "EllipseCloud", "LocalCov"]
@@ -26,16 +26,25 @@ __all__ = ["ellipse_cloud", "EllipseCloud", "LocalCov"]
 class EllipseCloud:
     """Container for an ellipse cloud with convenience methods."""
 
-    coef: numpy.ndarray  # (N, 6)
-    mean: numpy.ndarray  # (N, 2)
-    cov: numpy.ndarray  # (N, 2, 2)
+    coef: numpy.ndarray  # (N, m)
+    mean: numpy.ndarray  # (N, n)
+    cov: numpy.ndarray  # (N, n, n)
     k: int
     nbd: numpy.ndarray  # (N, k)  k-NN indices
     n: int = field(init=False)
+    n_dim: int = field(init=False)
 
     # ---- automatic field from coef.shape ---------------------------------
     def __post_init__(self):
         self.n = self.coef.shape[0]
+        try:
+            self.n_dim = infer_dim_from_coef_length(self.coef.shape[1])
+        except ValueError as exc:  # pragma: no cover - defensive
+            raise ValueError("Invalid conic coefficients for EllipseCloud") from exc
+        if self.mean.shape != (self.n, self.n_dim):
+            raise ValueError("Mean array shape does not match coefficient count")
+        if self.cov.shape != (self.n, self.n_dim, self.n_dim):
+            raise ValueError("Covariance array shape does not match coefficient count")
 
     # ---- basic Python protocol ------------------------------------------
     def __len__(self) -> int:
@@ -45,7 +54,7 @@ class EllipseCloud:
         return iter(self.coef)
 
     def __getitem__(self, idx) -> numpy.ndarray:
-        """Return the conic coefficient array (6,) for a single ellipse."""
+        """Return the conic coefficient array for a single ellipsoid."""
         return self.coef[idx]
 
     def __str__(self):
@@ -79,6 +88,9 @@ class EllipseCloud:
             Existing axes; if None, creates a new figure.
         """
         from .visualization import ellipse_patch
+
+        if self.n_dim != 2:
+            raise NotImplementedError("plot is only implemented for 2D ellipses")
 
         if ax is None:
             fig, ax = plt.subplots()
@@ -137,8 +149,8 @@ class EllipseCloud:
         """
         Parameters
         ----------
-        X : ndarray, shape (N, 2)
-            Input point cloud (x, y)
+        X : ndarray, shape (N, n)
+            Input point cloud in ``n`` dimensions.
         method : str
             Conversion algorithm. The supported method is "local_cov".
         rescaling : str
@@ -184,7 +196,7 @@ class EllipseCloud:
                 f"Unknown method '{method}':\n"
                 + "The supported method is 'median' or 'average'."
             )
-        ell_scale = ell_scales[1] ** 2 / ell_scales[0]
+        ell_scale = ell_scales[-1] ** 2 / ell_scales[0]
         self.cov /= ell_scale**2
         self.coef *= ell_scale**2
         return float(ell_scale)
@@ -208,8 +220,8 @@ class LocalCov:
         """
         Parameters
         ----------
-        X : ndarray, shape (N, 2)
-            Input point cloud (x, y)
+        X : ndarray, shape (N, n)
+            Input point cloud in ``n`` dimensions.
 
         Returns
         -------

--- a/src/ellphi/geometry.py
+++ b/src/ellphi/geometry.py
@@ -1,16 +1,8 @@
-"""
-ellphi.geometry  –  geometric helpers for ellipse cloud
-=======================================================
-
-Key API (all return NumPy float64):
-
-- unit_vector(theta)
-- axes_from_cov(cov, scale=1.0)
-- coef_from_axes(X, r0, r1, theta)  # centre+axes → (6,)
-- coef_from_cov(X, cov, scale=1.0)  # centre+cov → (6,)
-"""
+"""Geometric helpers for ellipse and ellipsoid clouds."""
 
 from __future__ import annotations
+
+from typing import Tuple
 
 import numpy
 
@@ -19,12 +11,16 @@ __all__ = [
     "axes_from_cov",
     "coef_from_axes",
     "coef_from_cov",
+    "pack_conic",
+    "unpack_conic",
+    "infer_dim_from_coef_length",
 ]
 
 
 # ------------------------------------------------------------------
 # Pure helpers
 # ------------------------------------------------------------------
+
 def unit_vector(theta: float) -> numpy.ndarray:  # noqa: D401
     """Return the unit vector (cosθ, sinθ)."""
     return numpy.transpose([numpy.cos(theta), numpy.sin(theta)])
@@ -45,6 +41,7 @@ def axes_from_cov(cov: numpy.ndarray, /, *, scale: float = 1.0):
 # ------------------------------------------------------------------
 # Shared core formula (broadcast-friendly)
 # ------------------------------------------------------------------
+
 def _coef_core(X, r0, r1, cos, sin):
     """Return stacked [a,b,c,d,e,f] along last dimension."""
     x, y = numpy.transpose(X)
@@ -60,22 +57,98 @@ def _coef_core(X, r0, r1, cos, sin):
 
 
 # ------------------------------------------------------------------
-# Public façade
+# Symmetric quadratic-form utilities (n-dimensional)
 # ------------------------------------------------------------------
+
+def infer_dim_from_coef_length(length: int) -> int:
+    """Return the dimensionality ``n`` encoded by a coefficient vector."""
+
+    if length < 3:
+        raise ValueError("Coefficient length must encode at least a 2D conic")
+    root = numpy.sqrt(8 * length + 1.0)
+    n = int(round((root - 3.0) / 2.0))
+    if (n + 1) * (n + 2) // 2 != length:
+        raise ValueError(f"Coefficient length {length} is not valid for a conic")
+    return n
+
+
+def _triangular_indices(n: int) -> Tuple[numpy.ndarray, numpy.ndarray]:
+    return numpy.triu_indices(n)
+
+
+def pack_conic(A: numpy.ndarray, b: numpy.ndarray, c: numpy.ndarray) -> numpy.ndarray:
+    """Pack ``(A, b, c)`` into flattened conic coefficients."""
+
+    A = numpy.asarray(A, dtype=float)
+    b = numpy.asarray(b, dtype=float)
+    c = numpy.asarray(c, dtype=float)
+
+    if A.ndim < 2:
+        raise ValueError("A must have at least two dimensions")
+    n = A.shape[-1]
+    if A.shape[-2] != n:
+        raise ValueError("A must be a square matrix")
+    if b.shape[-1] != n:
+        raise ValueError("Linear term dimensionality mismatch")
+
+    base_shape = numpy.broadcast_shapes(A.shape[:-2], b.shape[:-1], c.shape)
+    A = numpy.broadcast_to(A, base_shape + (n, n))
+    b = numpy.broadcast_to(b, base_shape + (n,))
+    c = numpy.broadcast_to(c, base_shape)
+
+    tri_i, tri_j = _triangular_indices(n)
+    tri_count = len(tri_i)
+    total = (n + 1) * (n + 2) // 2
+    out = numpy.empty(base_shape + (total,), dtype=float)
+
+    for idx, (i, j) in enumerate(zip(tri_i, tri_j)):
+        out[..., idx] = A[..., i, j]
+
+    out[..., tri_count : tri_count + n] = b
+    out[..., -1] = c
+    return out
+
+
+def unpack_conic(
+    coef: numpy.ndarray,
+) -> tuple[numpy.ndarray, numpy.ndarray, numpy.ndarray]:
+    """Return ``(A, b, c)`` for the supplied conic coefficients."""
+
+    coef = numpy.asarray(coef, dtype=float)
+    squeeze = coef.ndim == 1
+    if squeeze:
+        coef = coef[numpy.newaxis, :]
+
+    length = coef.shape[-1]
+    n = infer_dim_from_coef_length(length)
+    tri_i, tri_j = _triangular_indices(n)
+    tri_count = len(tri_i)
+
+    quad = coef[..., :tri_count]
+    linear = coef[..., tri_count : tri_count + n]
+    const = coef[..., -1]
+
+    shape = coef.shape[:-1]
+    A = numpy.zeros(shape + (n, n), dtype=float)
+    for idx, (i, j) in enumerate(zip(tri_i, tri_j)):
+        A[..., i, j] = quad[..., idx]
+        if i != j:
+            A[..., j, i] = quad[..., idx]
+
+    if squeeze:
+        return A[0], linear[0], numpy.asarray(const[0])
+    return A, linear, const
 
 
 def _inv_broadcast(cov: numpy.ndarray) -> numpy.ndarray:
-    """Vectorized inverse of a batch of 2x2 matrices."""
-    a, b, c, d = cov[:, 0, 0], cov[:, 0, 1], cov[:, 1, 0], cov[:, 1, 1]
-    det = a * d - b * c
-    inv_det = 1.0 / det
-    inv_cov = numpy.empty_like(cov)
-    inv_cov[:, 0, 0] = d * inv_det
-    inv_cov[:, 0, 1] = -b * inv_det
-    inv_cov[:, 1, 0] = -c * inv_det
-    inv_cov[:, 1, 1] = a * inv_det
-    return inv_cov
+    """Vectorized inverse of a batch of covariance matrices."""
 
+    return numpy.linalg.inv(cov)
+
+
+# ------------------------------------------------------------------
+# Public façade
+# ------------------------------------------------------------------
 
 def coef_from_axes(X: float, r0: float, r1: float, theta: float) -> numpy.ndarray:
     """Centre & axes → conic coefficient array (6,)."""
@@ -90,23 +163,22 @@ def coef_from_cov(
     scale: float = 1.0,
 ) -> numpy.ndarray:
     """Centre + covariance → conic coefficients."""
-    X = numpy.array(X)
-    if len(X.shape) <= 1:
-        X = X[None, :]  # Extend if single observation
-    if len(cov.shape) <= 2:
-        cov = cov[None, :, :]  # Extend if single observation
-    centers = X[:, :, None]
+
+    X = numpy.asarray(X, dtype=float)
+    cov = numpy.asarray(cov, dtype=float)
+
+    if X.ndim == 1:
+        X = X[numpy.newaxis, :]
+    if cov.ndim == 2:
+        cov = cov[numpy.newaxis, :, :]
+
+    if X.shape[0] != cov.shape[0]:
+        raise ValueError("Number of centres and covariance matrices must match")
+    if X.shape[1] != cov.shape[1] or cov.shape[1] != cov.shape[2]:
+        raise ValueError("Covariance matrices must align with centre dimensions")
+
+    centers = X[..., :, None]
     matrices = _inv_broadcast(cov) / scale**2
-    coef_b = -matrices @ centers
-    coef_c = centers.transpose(0, 2, 1) @ matrices @ centers
-    return numpy.stack(
-        [
-            matrices[:, 0, 0],
-            matrices[:, 0, 1],
-            matrices[:, 1, 1],
-            coef_b[:, 0].ravel(),
-            coef_b[:, 1].ravel(),
-            coef_c.ravel(),
-        ],
-        axis=-1,
-    )
+    coef_b = -(matrices @ centers)[..., 0]
+    coef_c = numpy.einsum("...i,...i->...", X, -coef_b)
+    return pack_conic(matrices, coef_b, coef_c)

--- a/src/ellphi/solver.py
+++ b/src/ellphi/solver.py
@@ -8,6 +8,7 @@ import numpy
 
 from . import _solver_python as _py
 from . import _tangency_cpp as _cpp
+from .geometry import infer_dim_from_coef_length
 
 __all__ = [
     "quad_eval",
@@ -50,16 +51,24 @@ def has_cpp_backend() -> bool:
 def _extract_coef_array(ellcloud: Iterable[numpy.ndarray]) -> numpy.ndarray:
     coef = getattr(ellcloud, "coef", ellcloud)
     array = numpy.asarray(coef, dtype=float)
-    if array.ndim != 2 or array.shape[1] != 6:
-        raise ValueError("Expected ellipse coefficients with shape (n, 6)")
+    if array.ndim != 2:
+        raise ValueError("Expected ellipse coefficients with shape (n, m)")
+    try:
+        infer_dim_from_coef_length(array.shape[1])
+    except ValueError as exc:  # pragma: no cover - defensive
+        raise ValueError("Invalid conic coefficient length") from exc
     return array
 
 
-def _should_use_cpp(backend: str) -> bool:
+def _should_use_cpp(backend: str, *, dim: int | None = None) -> bool:
     if backend not in _BACKEND_NAMES:
         raise ValueError(
             f"Unknown backend '{backend}'. Expected one of {', '.join(_BACKEND_NAMES)}"
         )
+    if dim is not None and dim != 2:
+        if backend == "cpp":
+            raise RuntimeError("C++ backend currently supports only 2D conics")
+        return False
     if backend == "cpp":
         if not has_cpp_backend():
             raise RuntimeError("C++ backend requested but not available")
@@ -87,7 +96,11 @@ def tangency(
     """Return (t, point, μ) at which two ellipses are tangent."""
 
     method_literal = _normalize_method(method)
-    if _should_use_cpp(backend):
+    dim_p = infer_dim_from_coef_length(pcoef.shape[0])
+    dim_q = infer_dim_from_coef_length(qcoef.shape[0])
+    if dim_p != dim_q:
+        raise ValueError("Conics must have matching dimensionality")
+    if _should_use_cpp(backend, dim=dim_p):
         return _cpp.tangency(
             pcoef,
             qcoef,
@@ -126,8 +139,9 @@ def pdist_tangency(
         Backend used for the tangency computation.
     """
 
-    if _should_use_cpp(backend):
-        coef = _extract_coef_array(ellcloud)
+    coef = _extract_coef_array(ellcloud)
+    dim = infer_dim_from_coef_length(coef.shape[1])
+    if _should_use_cpp(backend, dim=dim):
         return _cpp.pdist_tangency(coef)
     if parallel:
         return _pdist_tangency_parallel(ellcloud, n_jobs=n_jobs)

--- a/tests/factories.py
+++ b/tests/factories.py
@@ -1,7 +1,3 @@
-"""Factories shared across unit tests."""
-
-from __future__ import annotations
-
 import numpy as np
 from numpy.typing import NDArray
 
@@ -15,27 +11,34 @@ def rotation_matrix(angle: float) -> NDArray[np.float64]:
     return np.array([[cos, -sin], [sin, cos]], dtype=float)
 
 
-def random_covariance(rng: np.random.Generator) -> NDArray[np.float64]:
-    """Draw a random, symmetric positive-definite 2×2 covariance matrix."""
-    axes = rng.uniform(1.0, 6.0, size=2)
-    rot = rotation_matrix(rng.uniform(0.0, np.pi))
-    return rot @ np.diag(axes) @ rot.T
+def random_covariance(rng: np.random.Generator, dim: int = 2) -> NDArray[np.float64]:
+    """Draw a random, symmetric positive-definite covariance matrix."""
+    if dim == 2:
+        axes = rng.uniform(1.0, 6.0, size=2)
+        rot = rotation_matrix(rng.uniform(0.0, np.pi))
+        return rot @ np.diag(axes) @ rot.T
+    mat = rng.normal(size=(dim, dim))
+    cov = mat @ mat.T
+    cov += dim * np.eye(dim)
+    return cov
 
 
 def random_coef_pair(
-    rng: np.random.Generator,
+    rng: np.random.Generator, *, dim: int = 2
 ) -> tuple[np.ndarray, np.ndarray]:
-    """Return two random ellipse coefficients using consistent sampling."""
-    means = rng.uniform(-50.0, 50.0, size=(2, 2))
-    covs = np.stack([random_covariance(rng) for _ in range(2)])
+    """Return two random ellipsoid coefficients using consistent sampling."""
+    means = rng.uniform(-5.0, 5.0, size=(2, dim))
+    covs = np.stack([random_covariance(rng, dim=dim) for _ in range(2)])
     coefs = coef_from_cov(means, covs)
     return coefs[0], coefs[1]
 
 
-def random_cloud(rng: np.random.Generator, n_ellipses: int) -> EllipseCloud:
-    """Construct an ``EllipseCloud`` populated with random ellipses."""
-    means = rng.uniform(-50.0, 50.0, size=(n_ellipses, 2))
-    covs = np.stack([random_covariance(rng) for _ in range(n_ellipses)])
+def random_cloud(
+    rng: np.random.Generator, *, n_ellipses: int, dim: int = 2
+) -> EllipseCloud:
+    """Construct an ``EllipseCloud`` populated with random ellipsoids."""
+    means = rng.uniform(-10.0, 10.0, size=(n_ellipses, dim))
+    covs = np.stack([random_covariance(rng, dim=dim) for _ in range(n_ellipses)])
     coefs = coef_from_cov(means, covs)
     dummy_nbd = np.empty((n_ellipses, 0), dtype=int)
     return EllipseCloud(coef=coefs, mean=means, cov=covs, k=0, nbd=dummy_nbd)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -4,6 +4,7 @@ from typing import Any, cast
 import numpy as np
 import pytest
 from ellphi import coef_from_axes, tangency
+from ellphi.geometry import coef_from_cov
 from ellphi.solver import quad_eval
 from tests.factories import random_coef_pair, rotation_matrix
 
@@ -198,7 +199,30 @@ def test_circle_tangency_matches_closed_form(case: CircleCase, solver_backend):
 
 
 # -----------------------------------------------------------------------------
-# 5. Axis-aligned ellipses: tangency along the major axis direction
+# 5. Three-dimensional spheres (Python backend)
+# -----------------------------------------------------------------------------
+def test_sphere_tangency_matches_closed_form():
+    center_p = np.array([0.0, 0.0, 0.0], dtype=float)
+    center_q = np.array([4.0, 0.0, 0.0], dtype=float)
+    radius_p, radius_q = 1.0, 2.0
+
+    p = coef_from_cov(center_p, np.eye(3) * radius_p**2)[0]
+    q = coef_from_cov(center_q, np.eye(3) * radius_q**2)[0]
+
+    res = tangency(p, q, backend="python")
+
+    distance = np.linalg.norm(center_q - center_p)
+    expected_t = distance / (radius_p + radius_q)
+    expected_mu = radius_q / (radius_p + radius_q)
+    expected_point = center_p + (center_q - center_p) / distance * (radius_p * expected_t)
+
+    assert res.t == pytest.approx(expected_t, rel=1e-9, abs=1e-12)
+    assert res.mu == pytest.approx(expected_mu, rel=1e-9, abs=1e-12)
+    np.testing.assert_allclose(res.point, expected_point, rtol=1e-9, atol=1e-12)
+
+
+# -----------------------------------------------------------------------------
+# 6. Axis-aligned ellipses: tangency along the major axis direction
 # -----------------------------------------------------------------------------
 def test_axis_aligned_ellipses_have_expected_t(
     axis_aligned_case: AxisAlignedCase, solver_backend
@@ -214,7 +238,7 @@ def test_axis_aligned_ellipses_have_expected_t(
 
 
 # -----------------------------------------------------------------------------
-# 6. Rotating the entire configuration does not change the tangency scale
+# 7. Rotating the entire configuration does not change the tangency scale
 # -----------------------------------------------------------------------------
 @pytest.mark.parametrize("angle", [0.2, 0.8, 1.3])
 def test_rotational_invariance(
@@ -238,7 +262,7 @@ def test_rotational_invariance(
 
 
 # -----------------------------------------------------------------------------
-# 7. Generic properties at the tangency point
+# 8. Generic properties at the tangency point
 # -----------------------------------------------------------------------------
 
 
@@ -272,7 +296,7 @@ def test_tangency_point_satisfies_quadratic_and_normal_alignment(solver_backend)
 
 
 # -----------------------------------------------------------------------------
-# 8. Axis-aligned ellipses: tangency time matches analytic distance formula
+# 9. Axis-aligned ellipses: tangency time matches analytic distance formula
 # -----------------------------------------------------------------------------
 def test_axis_aligned_scaling_matches_sum_of_axes(solver_backend):
     case = AxisAlignedCase(
@@ -290,7 +314,7 @@ def test_axis_aligned_scaling_matches_sum_of_axes(solver_backend):
 
 
 # -----------------------------------------------------------------------------
-# 9. Tangency point must lie on both scaled ellipses
+# 10. Tangency point must lie on both scaled ellipses
 # -----------------------------------------------------------------------------
 def test_tangency_point_satisfies_both_ellipses(solver_backend):
     p = coef_from_axes([0.4, -0.5], 1.1, 0.6, 0.8)
@@ -305,7 +329,7 @@ def test_tangency_point_satisfies_both_ellipses(solver_backend):
 
 
 # -----------------------------------------------------------------------------
-# 10. Translating both ellipses should translate the solution
+# 11. Translating both ellipses should translate the solution
 # -----------------------------------------------------------------------------
 def test_tangency_translation_invariance(solver_backend):
     c_p = np.array([-0.2, 0.3])
@@ -326,7 +350,7 @@ def test_tangency_translation_invariance(solver_backend):
 
 
 # -----------------------------------------------------------------------------
-# 11. Identical ellipses touch immediately (t ≈ 0)
+# 12. Identical ellipses touch immediately (t ≈ 0)
 # -----------------------------------------------------------------------------
 def test_identical_ellipses_touch_at_zero_time(solver_backend):
     center = np.array([2.3, -1.1])
@@ -340,7 +364,7 @@ def test_identical_ellipses_touch_at_zero_time(solver_backend):
 
 
 # -----------------------------------------------------------------------------
-# 12. Alternative scalar-root methods agree with the default strategy
+# 13. Alternative scalar-root methods agree with the default strategy
 # -----------------------------------------------------------------------------
 @pytest.mark.parametrize("method", ["bisect", "brentq", "brenth"])
 def test_scalar_root_methods_match_default(method: str, solver_backend):
@@ -356,7 +380,7 @@ def test_scalar_root_methods_match_default(method: str, solver_backend):
 
 
 # -----------------------------------------------------------------------------
-# 13. Newton method works when supplied with an initial guess
+# 14. Newton method works when supplied with an initial guess
 # -----------------------------------------------------------------------------
 def test_newton_method_with_initial_guess(solver_backend):
     p = coef_from_axes([0.3, -0.7], 1.2, 0.9, 0.4)
@@ -371,7 +395,7 @@ def test_newton_method_with_initial_guess(solver_backend):
 
 
 # -----------------------------------------------------------------------------
-# 14. Edge cases for tangency
+# 15. Edge cases for tangency
 # -----------------------------------------------------------------------------
 def test_tangency_identical_ellipses(solver_backend):
     """Test tangency between two identical ellipses."""

--- a/tests/test_differentiable_solver.py
+++ b/tests/test_differentiable_solver.py
@@ -31,13 +31,15 @@ def solve_mu_forward_diff(
     return d_mu_dp, d_mu_dq
 
 
-def test_numerical_differentiation(rng):
+@pytest.mark.parametrize("dim", [2, 3])
+def test_numerical_differentiation(rng, dim):
     """The numerical Jacobian matches a forward-difference baseline."""
-    p, q = random_coef_pair(rng)
+    p, q = random_coef_pair(rng, dim=dim)
+    expected_len = (dim + 1) * (dim + 2) // 2
 
     d_mu_dp, d_mu_dq = solve_mu_numerical_diff(p, q)
-    assert d_mu_dp.shape == (6,), f"Expected shape (6,), but got {d_mu_dp.shape}"
-    assert d_mu_dq.shape == (6,), f"Expected shape (6,), but got {d_mu_dq.shape}"
+    assert d_mu_dp.shape == (expected_len,), f"Unexpected shape {d_mu_dp.shape}"
+    assert d_mu_dq.shape == (expected_len,), f"Unexpected shape {d_mu_dq.shape}"
 
     d_mu_dp_forward, d_mu_dq_forward = solve_mu_forward_diff(p, q)
     np.testing.assert_allclose(
@@ -56,11 +58,12 @@ def test_numerical_differentiation(rng):
     )
 
 
-def test_analytic_gradients_match_central_difference(rng):
+@pytest.mark.parametrize("dim", [2, 3])
+def test_analytic_gradients_match_central_difference(rng, dim):
     """The analytic gradients agree with central differences."""
 
     for _ in range(5):
-        p, q = random_coef_pair(rng)
+        p, q = random_coef_pair(rng, dim=dim)
         mu, d_mu_dp, d_mu_dq = solve_mu_gradients(p, q)
         d_mu_dp_num, d_mu_dq_num = solve_mu_numerical_diff(p, q)
 

--- a/tests/test_ellcloud.py
+++ b/tests/test_ellcloud.py
@@ -14,6 +14,7 @@ def test_local_cov_uses_actual_neighbourhood_size():
     assert ellcloud.cov.shape[0] == 1
     expected_cov = np.cov(X, rowvar=False, bias=False)
     assert ellcloud.cov[0] == pytest.approx(expected_cov)
+    assert ellcloud.n_dim == 2
 
 
 def test_local_cov_requires_k_at_least_two():
@@ -62,3 +63,22 @@ def test_local_cov_merges_identical_neighbourhoods():
     assert ellcloud.nbd.shape == (2, 3)
     assert np.array_equal(ellcloud.nbd, np.array([[0, 1, 2], [3, 4, 5]]))
     assert np.array_equal(ellcloud.nbd, np.sort(ellcloud.nbd, axis=1))
+
+
+def test_local_cov_handles_three_dimensions():
+    X = np.array(
+        [
+            [0.0, 0.0, 0.0],
+            [1.0, 0.0, 0.0],
+            [0.0, 1.0, 0.0],
+            [0.0, 0.0, 1.0],
+        ]
+    )
+
+    ellcloud = EllipseCloud.from_local_cov(X, k=4)
+    assert ellcloud.n_dim == 3
+    assert ellcloud.mean.shape == (ellcloud.n, 3)
+    assert ellcloud.cov.shape == (ellcloud.n, 3, 3)
+
+    with pytest.raises(NotImplementedError):
+        ellcloud.plot()

--- a/tests/test_ellcloud_rescale.py
+++ b/tests/test_ellcloud_rescale.py
@@ -21,3 +21,16 @@ def test_rescale_returns_float_and_updates_arrays():
     assert isinstance(scale, float)
     np.testing.assert_allclose(cloud.cov, cov_before / scale**2)
     np.testing.assert_allclose(cloud.coef, coef_before * scale**2)
+
+
+def test_rescale_three_dimensional_cloud():
+    rng = np.random.default_rng(7)
+    cloud = random_cloud(rng, n_ellipses=4, dim=3)
+    cov_before = cloud.cov.copy()
+    coef_before = cloud.coef.copy()
+
+    scale = cloud.rescale()
+
+    assert isinstance(scale, float)
+    np.testing.assert_allclose(cloud.cov, cov_before / scale**2)
+    np.testing.assert_allclose(cloud.coef, coef_before * scale**2)

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -2,10 +2,13 @@ import numpy as np
 import pytest
 
 from ellphi.geometry import (
-    unit_vector,
     axes_from_cov,
     coef_from_axes,
     coef_from_cov,
+    infer_dim_from_coef_length,
+    pack_conic,
+    unpack_conic,
+    unit_vector,
 )
 
 
@@ -37,12 +40,67 @@ def test_axes_order():
 
 
 # ------------------------------------------------------------
-# 3. coef_from_cov agrees with coef_from_axes
+# 3. coef_from_cov agrees with matrix identities in any dimension
 # ------------------------------------------------------------
-def test_coef_from_cov():
+@pytest.mark.parametrize("dim", [2, 3])
+def test_coef_from_cov(dim):
+    rng = np.random.default_rng(42)
+    mean = rng.uniform(-2.0, 2.0, size=dim)
+    mat = rng.normal(size=(dim, dim))
+    cov = mat @ mat.T + np.eye(dim)
+
+    coef = coef_from_cov(mean, cov)[0]
+    A, b, c = unpack_conic(coef)
+
+    expected_A = np.linalg.inv(cov)
+    expected_b = -expected_A @ mean
+    expected_c = mean @ expected_A @ mean
+
+    np.testing.assert_allclose(A, expected_A, rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(b, expected_b, rtol=1e-12, atol=1e-12)
+    assert c == pytest.approx(expected_c, rel=1e-12, abs=1e-12)
+
+
+# ------------------------------------------------------------
+# 4. coef_from_cov matches coef_from_axes in 2D
+# ------------------------------------------------------------
+def test_coef_from_cov_matches_axes():
     cov = np.array([[4.0, 1.2], [1.2, 3.0]])
     x0, y0 = 0.3, -0.8
     r1, r2, th = axes_from_cov(cov)
     coef1 = coef_from_axes([x0, y0], r1, r2, th)
-    coef2 = coef_from_cov([x0, y0], cov)
+    coef2 = coef_from_cov([x0, y0], cov)[0]
     assert np.allclose(coef1, coef2, rtol=1e-12, atol=1e-12)
+
+
+# ------------------------------------------------------------
+# 5. Pack/unpack round-trip
+# ------------------------------------------------------------
+@pytest.mark.parametrize("dim", [2, 3, 5])
+def test_pack_unpack_roundtrip(dim):
+    rng = np.random.default_rng(123)
+    A = rng.normal(size=(dim, dim))
+    A = A @ A.T + np.eye(dim)
+    b = rng.normal(size=dim)
+    c = rng.normal()
+
+    coef = pack_conic(A, b, c)
+    A_rt, b_rt, c_rt = unpack_conic(coef)
+
+    np.testing.assert_allclose(A_rt, A, rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(b_rt, b, rtol=1e-12, atol=1e-12)
+    assert c_rt == pytest.approx(c, rel=1e-12, abs=1e-12)
+
+
+# ------------------------------------------------------------
+# 6. infer_dim_from_coef_length recovers dimensionality
+# ------------------------------------------------------------
+@pytest.mark.parametrize("dim", [2, 3, 7])
+def test_infer_dim_from_coef_length(dim):
+    length = (dim + 1) * (dim + 2) // 2
+    assert infer_dim_from_coef_length(length) == dim
+
+
+def test_infer_dim_from_coef_length_rejects_invalid():
+    with pytest.raises(ValueError):
+        infer_dim_from_coef_length(5)

--- a/tests/test_solver.py
+++ b/tests/test_solver.py
@@ -27,3 +27,12 @@ def test_pdist_tangency_consistency(ellipse_cloud, solver_backend):
         parallel_result,
         err_msg="Serial and parallel results are not close enough.",
     )
+
+
+def test_pdist_tangency_three_dimensions(rng):
+    """pdist_tangency works for 3D ellipsoids using the Python backend."""
+
+    cloud = random_cloud(rng, n_ellipses=8, dim=3)
+    serial = pdist_tangency(cloud, parallel=False, backend="python")
+    parallel = pdist_tangency(cloud, parallel=True, backend="python")
+    np.testing.assert_allclose(serial, parallel)

--- a/tests/test_tangent_pencil.py
+++ b/tests/test_tangent_pencil.py
@@ -168,16 +168,19 @@ def test_circle_center_jacobian_matches_manual_formula(case: CircleTangencyCase)
     np.testing.assert_allclose(jac, expected, rtol=1e-12, atol=1e-12)
 
 
-def test_center_jacobian_matches_finite_difference(rng: np.random.Generator):
+@pytest.mark.parametrize("dim", [2, 3])
+def test_center_jacobian_matches_finite_difference(
+    rng: np.random.Generator, dim: int
+):
     """`center_jacobian` matches a central-difference approximation."""
 
     for _ in range(5):
-        p, q = random_coef_pair(rng)
+        p, q = random_coef_pair(rng, dim=dim)
         mu = solve_mu(p, q)
         pencil = build_tangent_pencil(mu, p, q)
         jac = center_jacobian(pencil)
 
-        for idx in range(6):
+        for idx in range(jac.shape[0]):
             step = 1e-6
             coef_plus = pencil.coef.copy()
             coef_minus = pencil.coef.copy()


### PR DESCRIPTION
## Summary
- generalize the geometry utilities and solver pipeline to operate on n-dimensional conics
- extend EllipseCloud and LocalCov to handle higher-dimensional point clouds while preserving 2D plotting semantics
- add factories and tests that exercise 3D ellipsoid cases alongside the existing 2D coverage

## Testing
- poetry run pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d8ffe3830832399a5e800b4ac3561)