### PR TITLE
Add randomized high-dimensional tangency regression test

### DIFF
--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -4,7 +4,8 @@ from typing import Any, cast
 import numpy as np
 import pytest
 from ellphi import coef_from_axes, coef_from_cov, tangency
-from ellphi.solver import quad_eval
+from ellphi.geometry import unpack_single_conic
+from ellphi.solver import quad_eval, tangency as solver_tangency
 from tests.factories import random_coef_pair, rotation_matrix
 
 
@@ -133,6 +134,36 @@ def test_tangency_three_dimensional_spheres():
     assert res.t == pytest.approx(1.5)
     with pytest.raises(RuntimeError):
         tangency(p, q, backend="cpp")
+
+
+@pytest.mark.parametrize("dim", [3, 4])
+def test_tangency_random_high_dimension(dim: int, rng: np.random.Generator) -> None:
+    iterations = 5
+    for _ in range(iterations):
+        pcoef, qcoef = random_coef_pair(rng, dim=dim)
+        result = solver_tangency(pcoef, qcoef, backend="python")
+
+        point = result.point
+        assert point.shape == (dim,)
+
+        p_value = quad_eval(pcoef, point)
+        q_value = quad_eval(qcoef, point)
+        expected = result.t**2
+        assert p_value == pytest.approx(expected, rel=1e-7, abs=1e-10)
+        assert q_value == pytest.approx(expected, rel=1e-7, abs=1e-10)
+
+        Ap, bp, _ = unpack_single_conic(pcoef)
+        Aq, bq, _ = unpack_single_conic(qcoef)
+        grad_p = 2.0 * (Ap @ point) + 2.0 * bp
+        grad_q = 2.0 * (Aq @ point) + 2.0 * bq
+
+        combination = (1.0 - result.mu) * grad_p + result.mu * grad_q
+        np.testing.assert_allclose(
+            combination,
+            np.zeros_like(point),
+            rtol=1e-6,
+            atol=1e-6,
+        )
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add a randomized high-dimensional tangency regression test that validates points, distances, and gradients
- verify tangency results satisfy quadratic evaluations and Lagrange multiplier conditions for random ellipsoids

## Testing
- poetry run black src tests
- poetry run black --check src tests
- poetry run flake8
- poetry run mypy src tests
- poetry run pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691037bca62c83239dab3ebfa03171fc)