### PR TITLE
Align Python solver fallback with C++ elimination

### DIFF
--- a/docs/numerical-stability-report.md
+++ b/docs/numerical-stability-report.md
@@ -1,0 +1,18 @@
+# Numerical Stability Investigation (Python Backends)
+
+## CI and Dependency Baseline
+- CI runs on Ubuntu with Python 3.10 and 3.11, installing dependencies via Poetry and running flake8, black, pytest, mypy, and stubtest. 【F:.github/workflows/python-app.yml†L6-L46】
+- The Poetry lockfile currently resolves NumPy to 2.2.6 and SciPy to 1.15.3 for all supported interpreters (>=3.10). 【F:poetry.lock†L2111-L2174】【F:poetry.lock†L3435-L3498】
+
+## Findings
+- The divergent 5D test case (`tests/test_numerical_stability.py::test_divergent_algsig_newton_case`) succeeds on the C++ backend because its fallback solver performs Gaussian elimination with pivoting when Cholesky factorization fails. 【F:tests/test_numerical_stability.py†L5-L43】【F:src/ellphi/_tangency_cpp_impl.cpp†L300-L347】
+- The Python backend previously fell back to `numpy.linalg.lstsq`, which can follow a different numerical path depending on NumPy/LAPACK versions, leading to non-convergence on Python 3.11 with newer NumPy/SciPy.
+- Aligning the Python fallback with the C++ elimination path removes this source of version-dependent behavior and better matches the intended algorithm.
+
+## Changes Implemented
+- Added a Gaussian elimination solver with partial pivoting to the Python backend and swapped the fallback in `_center` to use it instead of `lstsq`, mirroring the C++ code path. 【F:src/ellphi/_solver_python.py†L38-L85】【F:src/ellphi/_solver_python.py†L125-L140】
+
+## Remaining Risk and Recommendations
+- Network restrictions in this environment prevented installing dependencies, so CI-equivalent test runs (black/flake8/pytest/mypy/stubtest) could not be executed here. Future validation should confirm the fix across Python 3.10/3.11 with NumPy 2.2.6 and SciPy 1.15.3. 【F:AGENTS.md†L15-L74】
+- To guard against similar regressions, consider expanding CI to a matrix over critical NumPy/SciPy versions (e.g., latest and minimum supported) alongside Python versions.
+- If further instability is observed, document any non-supported NumPy/SciPy releases and pin or exclude them in `pyproject.toml` along with release notes.

--- a/src/ellphi/_solver_python.py
+++ b/src/ellphi/_solver_python.py
@@ -62,6 +62,55 @@ def _x_prime_from_u(u: float | numpy.ndarray) -> float | numpy.ndarray:
     return 0.5 * (1.0 + u**2) ** (-1.5)
 
 
+# --- Linear Solvers ---
+
+
+def _gaussian_elimination(
+    A: numpy.ndarray, b: numpy.ndarray
+) -> numpy.ndarray:
+    """Solve a dense linear system using Gaussian elimination with pivoting.
+
+    The implementation mirrors the C++ backend's fallback used when Cholesky
+    factorization fails, ensuring both backends follow the same numerical path
+    across NumPy/SciPy versions.
+    """
+
+    matrix = numpy.array(A, dtype=float, copy=True)
+    rhs = numpy.array(b, dtype=float, copy=True)
+
+    if matrix.shape[0] != matrix.shape[1]:
+        raise ValueError("Matrix A must be square")
+
+    dim = matrix.shape[0]
+
+    for k in range(dim):
+        pivot_offset = int(numpy.argmax(numpy.abs(matrix[k:, k])))
+        pivot = k + pivot_offset
+        pivot_value = matrix[pivot, k]
+
+        if pivot_value == 0.0 or not numpy.isfinite(pivot_value):
+            raise linalg.LinAlgError("Degenerate conic (determinant zero)")
+
+        if pivot != k:
+            matrix[[k, pivot]] = matrix[[pivot, k]]
+            rhs[[k, pivot]] = rhs[[pivot, k]]
+
+        for i in range(k + 1, dim):
+            factor = matrix[i, k] / pivot_value
+            rhs[i] -= factor * rhs[k]
+            matrix[i, k:] -= factor * matrix[k, k:]
+
+    x = numpy.zeros(dim, dtype=float)
+    for i in range(dim - 1, -1, -1):
+        diag = matrix[i, i]
+        if diag == 0.0 or not numpy.isfinite(diag):
+            raise linalg.LinAlgError("Degenerate conic (determinant zero)")
+
+        x[i] = (rhs[i] - matrix[i, i + 1 :] @ x[i + 1 :]) / diag
+
+    return x
+
+
 # --- Core Solver Functions ---
 
 
@@ -151,10 +200,10 @@ def _center(coef: numpy.ndarray) -> numpy.ndarray:
         center = linalg.cho_solve(chol, -b, check_finite=False)
     except linalg.LinAlgError:
         try:
-            # Fallback to general linear solver, using lstsq for robustness
-            center = numpy.linalg.lstsq(A, -b, rcond=None)[0]
-        except numpy.linalg.LinAlgError:  # pragma: no cover - defensive
-            # If lstsq also fails, propagate NaN
+            # Fallback to match C++ backend: Gaussian elimination with pivoting
+            center = _gaussian_elimination(A, -b)
+        except linalg.LinAlgError:  # pragma: no cover - defensive
+            # If the fallback also fails, propagate NaN
             return numpy.full(A.shape[0], numpy.nan, dtype=float)
     return center
 


### PR DESCRIPTION
## Summary
- add a Gaussian-elimination fallback in the Python solver to mirror the C++ backend
- document CI Python/NumPy/SciPy baselines and investigation details in docs

## Testing
- not run (network access blocked Poetry installs)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693684027e2c8323b66afcb338689c90)