### PR TITLE
Document 0.1.2 release in release notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -2,7 +2,11 @@
 
 _No unreleased changes yet._
 
-## 0.1.2 - 2025-12-01
+## 0.1.2 - 2025-12-13
+
+This release packages the empirical hybrid tuning work and exposes the
+resulting iteration controls end-to-end so Python and C++ callers can
+reproduce the performance improvements.
 
 ### Added
 


### PR DESCRIPTION
## Summary
- move the previously unreleased entries into a 0.1.2 release section with a dated heading
- leave an empty Unreleased placeholder noting there are no pending changes

## Testing
- Not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693cfaba6f5883238378ae8ce34bc6b4)