### PR TITLE
Add version info helper and CLI entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,22 @@ For deeper workflows, see the accompanying notebooks:
 * [`eph-6rings-PH-figures.ipynb`](https://github.com/t-uda/ellphi/notebooks/eph-6rings-PH-figures.ipynb) – figures presented in ATMCS 2025 poster
 * [`ndim-demo-3d.ipynb`](https://github.com/t-uda/ellphi/notebooks/ndim-demo-3d.ipynb) – 3-D ellipsoid cloud + tangency distance walkthrough
 
-> **For ATMCS 2025 attendees**  
-> See **[`eph-6rings-PH-figures.ipynb`](https://github.com/t-uda/ellphi/notebooks/eph-6rings-PH-figures.ipynb)**  
+> **For ATMCS 2025 attendees**
+> See **[`eph-6rings-PH-figures.ipynb`](https://github.com/t-uda/ellphi/notebooks/eph-6rings-PH-figures.ipynb)**
 > which accompanies the conference poster.
+
+## Check the installed version
+
+Inside Python:
+
+```python
+import ellphi
+
+print(ellphi.version_info())
+```
+
+From the shell (requires a Poetry/`pip` installation):
+
+```bash
+ellphi --version
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,9 @@ dependencies = [
   "joblib>=1.3",
 ]
 
+[project.scripts]
+ellphi = "ellphi.__init__:_main"
+
 [project.urls]
 Homepage = "https://github.com/t-uda/ellphi"
 Repository = "https://github.com/t-uda/ellphi"

--- a/src/ellphi/__init__.py
+++ b/src/ellphi/__init__.py
@@ -55,4 +55,31 @@ __all__ = [
     "TangencyResult",
     "has_cpp_backend",
     "__version__",
+    "version_info",
 ]
+
+
+def version_info() -> str:
+    """Return the current :mod:`ellphi` version string."""
+
+    return __version__
+
+
+def _main() -> None:
+    """A minimal CLI for printing the current version."""
+
+    import argparse
+
+    parser = argparse.ArgumentParser(description="ellphi command-line interface")
+    parser.add_argument(
+        "--version",
+        action="store_true",
+        help="Print the installed ellphi version and exit",
+    )
+
+    args = parser.parse_args()
+
+    if args.version:
+        print(version_info())
+    else:
+        parser.print_help()

--- a/src/ellphi/__init__.pyi
+++ b/src/ellphi/__init__.pyi
@@ -24,6 +24,8 @@ from .solver import (
 )
 from ._version import __version__ as __version__
 
+def version_info() -> str: ...
+
 __all__ = [
     "unit_vector",
     "axes_from_cov",
@@ -40,4 +42,5 @@ __all__ = [
     "has_cpp_backend",
     "FloatArray",
     "__version__",
+    "version_info",
 ]


### PR DESCRIPTION
## Summary
- add an ellphi.version_info() helper and expose the version through a minimal CLI entrypoint
- document how to retrieve the installed version from Python or the shell

## Testing
- poetry run black src tests
- poetry run black --check src tests
- poetry run flake8
- poetry run mypy src tests
- MYPYPATH=src poetry run stubtest ellphi --allowlist stubtest-allowlist.txt
- poetry run pytest


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d45f610ec832382ad0bc31454e68a)