### PR TITLE
Align 0.1.1 release notes content

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,20 +1,28 @@
 ## Unreleased
 
+No unreleased changes.
+
+## 0.1.1 - 2025-12-01
+
 ### Added
 
-- `scripts/hybrid_tuning.py` plus the accompanying
+- `scripts/hybrid_tuning.py` and the accompanying
   `docs/hybrid_tuning_summary.json` artifact summarising the empirical tuning
   run. The script generates extreme ellipse pairs across dimensions,
   benchmarks `ellphi.solver.tangency` for every requested backend (Python and
-  C++ when available), and now reports aggregate & per-dimension
+  C++ when available), and reports aggregate and per-dimension
   runtime/error/failure statistics in a Markdown table (with an opt-in plain
-  view). Accuracy is now based on the relative tangency residual (rather than
-  μ differences), and an optional `--plot-dir` flag emits log-log scatter
-  plots of median time vs. error per backend. New options allow supplying or
+  view). Accuracy now relies on the relative tangency residual (rather than μ
+  differences), and an optional `--plot-dir` flag emits log-log scatter plots
+  of median time vs. error per backend. New options allow supplying or
   persisting case sets (`--cases-input/--cases-output`), overriding hybrid
   iteration pairs (`--hybrid-combos`), and prefixing plot names to keep
-  multiple scenarios side by side, making it easy to reproduce and compare
-  the parameter sweep backing the hybrid defaults.
+  multiple scenarios side by side, making it easy to reproduce and compare the
+  parameter sweep backing the hybrid defaults.
+- Full n-dimensional support for tangency solving across Python and C++ backends, including new conic
+  packing helpers, EllipseCloud dimension tracking, and expanded differentiable gradient coverage with
+  high-dimensional regression tests.
+- A dedicated 3-D ellipsoid demo notebook plus documentation of the ndim extension review.
 
 ### Changed
 
@@ -23,27 +31,15 @@
   historical 2D tuning (8 Brent / 3 Newton iterations) is retained, while n>2
   problems use the empirically tuned 28 / 6 budget. Dispatch helpers,
   differentiable solvers, and tests now accept the new keyword arguments.
-
-## 0.1.1 - 2025-11-09
-
-### Added
-
-- Full n-dimensional support for tangency solving across Python and C++ backends, including new conic
-packing helpers, EllipseCloud dimension tracking, and expanded differentiable gradient coverage with
-high-dimensional regression tests.
-- A dedicated 3-D ellipsoid demo notebook plus documentation of the ndim extension review.
+- Dropped support for Python 3.9. Python 3.10 or newer is now required.
 
 ### Fixed
 
 - The C++ backend now validates coefficient/point buffer lengths and clamps negative quadratic
-evaluations before taking square roots, while the Python wrapper rejects malformed coefficient arrays
-early.
-
-### Changed
-
-- Dropped support for Python 3.9. Python 3.10 or newer is now required.
+  evaluations before taking square roots, while the Python wrapper rejects malformed coefficient arrays
+  early.
 
 ### Tooling
 
 - AGENTS.md documents the exact CI command checklist and black[jupyter] is added so notebooks are
-formatted consistently.
+  formatted consistently.


### PR DESCRIPTION
## Summary
- merge the n-dimensional support release notes into the 0.1.1 section since 0.1.0 notes are not yet present
- remove the unused 0.1.0 heading while keeping the fixed/tooling items under 0.1.1

## Testing
- poetry run black src tests
- poetry run black --check src tests
- poetry run flake8
- poetry run mypy src tests
- MYPYPATH=src poetry run stubtest ellphi --allowlist stubtest-allowlist.txt
- poetry run pytest

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693d484860dc83239d8364a55756cab4)