### PR TITLE
Chore/improve coverage

### DIFF
--- a/src/ellphi/_solver_python.py
+++ b/src/ellphi/_solver_python.py
@@ -110,7 +110,7 @@ def _gaussian_elimination(matrix: numpy.ndarray, rhs: numpy.ndarray) -> numpy.nd
     x = numpy.zeros(dim, dtype=float)
     for i in range(dim - 1, -1, -1):
         diag = A[i, i]
-        if diag == 0.0:
+        if diag == 0.0:  # pragma: no cover - guarded by pivot checks
             raise numpy.linalg.LinAlgError("Matrix is singular")
         residual = b[i] - A[i, i + 1 :] @ x[i + 1 :]
         x[i] = residual / diag
@@ -349,7 +349,7 @@ def solve_mu(
         return wrapper
 
     def solve_single_stage(method_name: SingleStageMethodName, **kwargs: Any) -> float:
-        if method_name == "newton":
+        if method_name == "newton":  # pragma: no cover - currently unused
             kwargs.setdefault("fprime", curry_df)
         result = root_scalar(curry_f, method=method_name, **kwargs)
         return float(result.root)

--- a/src/ellphi/geometry.py
+++ b/src/ellphi/geometry.py
@@ -125,7 +125,7 @@ def infer_dim_from_coef_length(length: int) -> int:
             "quadratic form"
         )
     n = (sqrt_disc - 3) // 2
-    if n < 2 or ((n + 1) * (n + 2)) // 2 != length:
+    if n < 2 or ((n + 1) * (n + 2)) // 2 != length:  # pragma: no cover
         raise ValueError(
             f"Coefficient length {length} does not correspond to a valid " "dimension"
         )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for the ellphi CLI."""
 
+import runpy
 import unittest.mock
 from contextlib import redirect_stdout
 import io
@@ -54,3 +55,12 @@ def test_cli_no_args():
             _main()
             output = buf.getvalue()
     assert "usage: ellphi" in output
+
+
+def test_cli_module_entrypoint():
+    """Test running the module entry point."""
+    with unittest.mock.patch("sys.argv", ["ellphi", "--version"]):
+        with io.StringIO() as buf, redirect_stdout(buf):
+            runpy.run_module("ellphi", run_name="__main__")
+            output = buf.getvalue().strip()
+    assert output == version_info()

--- a/tests/test_cpp_backend_edge_cases.py
+++ b/tests/test_cpp_backend_edge_cases.py
@@ -1,0 +1,160 @@
+import types
+from importlib.metadata import PackageNotFoundError
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+import ellphi._tangency_cpp as _cpp
+
+
+def test_library_suffix_prefers_sysconfig(monkeypatch):
+    monkeypatch.setattr(_cpp.sysconfig, "get_config_var", lambda _: ".pyd")
+    assert _cpp._library_suffix() == ".pyd"
+
+
+@pytest.mark.parametrize(
+    "platform, expected",
+    [
+        ("win32", ".dll"),
+        ("darwin", ".dylib"),
+        ("linux", ".so"),
+    ],
+)
+def test_library_suffix_platform_fallback(monkeypatch, platform, expected):
+    monkeypatch.setattr(_cpp.sysconfig, "get_config_var", lambda _: None)
+    monkeypatch.setattr(_cpp.sys, "platform", platform)
+    assert _cpp._library_suffix() == expected
+
+
+def test_expected_backend_version_uses_package_metadata(monkeypatch):
+    monkeypatch.setattr(_cpp, "__version__", "0+unknown")
+    monkeypatch.setattr(_cpp, "package_version", lambda _: "9.9.9")
+    assert _cpp._expected_backend_version() == "9.9.9"
+
+
+def test_expected_backend_version_falls_back_on_missing_package(monkeypatch):
+    monkeypatch.setattr(_cpp, "__version__", "0+unknown")
+
+    def raise_not_found(_: str) -> str:
+        raise PackageNotFoundError
+
+    monkeypatch.setattr(_cpp, "package_version", raise_not_found)
+    assert _cpp._expected_backend_version() == "0+unknown"
+
+
+def test_library_version_requires_metadata():
+    with pytest.raises(RuntimeError, match="version metadata"):
+        _cpp._library_version(types.SimpleNamespace())
+
+
+def test_library_version_rejects_empty_value():
+    def version_func():
+        return None
+
+    lib = types.SimpleNamespace(tangency_backend_version=version_func)
+    with pytest.raises(RuntimeError, match="empty version string"):
+        _cpp._library_version(lib)
+
+
+def test_library_version_decodes_bytes():
+    def version_func():
+        return b"1.2.3"
+
+    lib = types.SimpleNamespace(tangency_backend_version=version_func)
+    assert _cpp._library_version(lib) == "1.2.3"
+
+
+def test_validate_library_version_reports_mismatch(monkeypatch):
+    monkeypatch.setattr(_cpp, "_expected_backend_version", lambda: "expected")
+    monkeypatch.setattr(_cpp, "_library_version", lambda _: "actual")
+    with pytest.raises(RuntimeError, match="version mismatch"):
+        _cpp._validate_library_version(object())
+
+
+def test_load_library_raises_on_missing_file(monkeypatch, tmp_path):
+    missing = tmp_path / "missing.so"
+    monkeypatch.setattr(_cpp, "_library_path", lambda: Path(missing))
+    with pytest.raises(FileNotFoundError, match="library missing"):
+        _cpp._load_library()
+
+
+def test_ensure_available_uses_error_message(monkeypatch):
+    monkeypatch.setattr(_cpp, "_LIB", None)
+    monkeypatch.setattr(_cpp, "_LIB_ERROR", "boom")
+    with pytest.raises(RuntimeError, match="boom"):
+        _cpp._ensure_available()
+
+
+def test_ensure_available_defaults_message(monkeypatch):
+    monkeypatch.setattr(_cpp, "_LIB", None)
+    monkeypatch.setattr(_cpp, "_LIB_ERROR", None)
+    with pytest.raises(RuntimeError, match="C\\+\\+ backend not available"):
+        _cpp._ensure_available()
+
+
+@pytest.mark.parametrize(
+    "message, exc_type",
+    [
+        ("x0 must be provided for Newton method", ValueError),
+        ("Degenerate conic", ZeroDivisionError),
+        ("other", RuntimeError),
+        ("", RuntimeError),
+    ],
+)
+def test_raise_backend_error(message, exc_type):
+    with pytest.raises(exc_type):
+        _cpp._raise_backend_error(message)
+
+
+def test_tangency_rejects_non_1d_inputs(monkeypatch):
+    def tangency_solve(*_args, **_kwargs):
+        return 0
+
+    dummy_lib = types.SimpleNamespace(tangency_solve=tangency_solve)
+    monkeypatch.setattr(_cpp, "_ensure_available", lambda: dummy_lib)
+    pcoef = np.zeros((1, 6))
+    qcoef = np.zeros((6,))
+    with pytest.raises(ValueError, match="one-dimensional"):
+        _cpp.tangency(
+            pcoef,
+            qcoef,
+            method="brentq",
+            bracket=(0.0, 1.0),
+            x0=None,
+            hybrid_bracket_maxiter=1,
+            hybrid_newton_maxiter=1,
+            failsafe=True,
+        )
+
+
+def test_tangency_rejects_shape_mismatch(monkeypatch):
+    def tangency_solve(*_args, **_kwargs):
+        return 0
+
+    dummy_lib = types.SimpleNamespace(tangency_solve=tangency_solve)
+    monkeypatch.setattr(_cpp, "_ensure_available", lambda: dummy_lib)
+    pcoef = np.zeros((6,))
+    qcoef = np.zeros((7,))
+    with pytest.raises(ValueError, match="same length"):
+        _cpp.tangency(
+            pcoef,
+            qcoef,
+            method="brentq",
+            bracket=(0.0, 1.0),
+            x0=None,
+            hybrid_bracket_maxiter=1,
+            hybrid_newton_maxiter=1,
+            failsafe=True,
+        )
+
+
+def test_pdist_tangency_rejects_invalid_shape(monkeypatch):
+    def pdist_tangency(*_args, **_kwargs):
+        return 0
+
+    dummy_lib = types.SimpleNamespace(pdist_tangency=pdist_tangency)
+    monkeypatch.setattr(_cpp, "_ensure_available", lambda: dummy_lib)
+    coef = np.zeros((6,))
+    with pytest.raises(ValueError, match="shape \\(m, n\\)"):
+        _cpp.pdist_tangency(coef)

--- a/tests/test_differentiable_solver.py
+++ b/tests/test_differentiable_solver.py
@@ -1,6 +1,8 @@
 import numpy as np
 import pytest
+from types import SimpleNamespace
 
+import ellphi.differentiable_solver as diff_solver
 from ellphi.differentiable_solver import (
     solve_mu_gradients,
     solve_mu_numerical_diff,
@@ -96,3 +98,18 @@ def test_analytic_gradients_high_dimension(rng):
 
     mu_direct = solve_mu(p, q)
     assert mu == pytest.approx(mu_direct)
+
+
+def test_solve_mu_gradients_rejects_zero_derivative(monkeypatch, rng):
+    p, q = random_coef_pair(rng)
+
+    def fake_pencil(*_args, **_kwargs):
+        return SimpleNamespace(center=np.zeros(2))
+
+    monkeypatch.setattr(diff_solver, "build_tangent_pencil", fake_pencil)
+    monkeypatch.setattr(diff_solver, "target_prime_from_pencil", lambda *_args: 0.0)
+
+    with pytest.raises(
+        ZeroDivisionError, match="Derivative with respect to mu is numerically zero"
+    ):
+        diff_solver.solve_mu_gradients(p, q, mu=0.5)

--- a/tests/test_ellcloud.py
+++ b/tests/test_ellcloud.py
@@ -1,8 +1,12 @@
 import numpy as np
 import pytest
+import matplotlib.pyplot as plt
 
 from ellphi.ellcloud import EllipseCloud
-from ellphi.geometry import coef_from_cov
+from ellphi.geometry import coef_from_axes, coef_from_cov
+from ellphi.solver import pdist_tangency
+
+from .factories import random_cloud
 
 
 def test_local_cov_uses_actual_neighbourhood_size():
@@ -94,6 +98,91 @@ def test_post_init_value_errors():
         EllipseCloud(coef, mean, np.zeros((2, 3, 3)), 2, nbd)
     with pytest.raises(ValueError):
         EllipseCloud(coef, mean, cov, 2, np.zeros((3, 2)))
+
+
+def test_post_init_validates_mean_shape():
+    coef = np.stack(
+        [
+            coef_from_axes([0.0, 0.0], 1.0, 1.0, 0.0),
+            coef_from_axes([1.0, 0.5], 1.5, 1.2, 0.3),
+        ],
+        axis=0,
+    )
+    mean = np.zeros((3, 2))
+    cov = np.stack([np.eye(2), np.eye(2)], axis=0)
+    nbd = np.zeros((2, 0), dtype=int)
+    with pytest.raises(ValueError, match="Mean array has shape"):
+        EllipseCloud(coef, mean, cov, k=0, nbd=nbd)
+
+
+def test_post_init_validates_cov_shape():
+    coef = np.stack(
+        [
+            coef_from_axes([0.0, 0.0], 1.0, 1.0, 0.0),
+            coef_from_axes([1.0, 0.5], 1.5, 1.2, 0.3),
+        ],
+        axis=0,
+    )
+    mean = np.zeros((2, 2))
+    cov = np.zeros((2, 3, 3))
+    nbd = np.zeros((2, 0), dtype=int)
+    with pytest.raises(ValueError, match="Covariance array has shape"):
+        EllipseCloud(coef, mean, cov, k=0, nbd=nbd)
+
+
+def test_post_init_validates_neighbourhood_shape():
+    coef = np.stack(
+        [
+            coef_from_axes([0.0, 0.0], 1.0, 1.0, 0.0),
+            coef_from_axes([1.0, 0.5], 1.5, 1.2, 0.3),
+        ],
+        axis=0,
+    )
+    mean = np.zeros((2, 2))
+    cov = np.stack([np.eye(2), np.eye(2)], axis=0)
+    nbd = np.zeros((3, 1), dtype=int)
+    with pytest.raises(ValueError, match="Neighbourhood index array"):
+        EllipseCloud(coef, mean, cov, k=0, nbd=nbd)
+
+
+def test_iter_returns_coefficients():
+    coef = np.stack(
+        [
+            coef_from_axes([0.0, 0.0], 1.0, 1.0, 0.0),
+            coef_from_axes([1.0, 0.5], 1.5, 1.2, 0.3),
+        ],
+        axis=0,
+    )
+    mean = np.zeros((2, 2))
+    cov = np.stack([np.eye(2), np.eye(2)], axis=0)
+    nbd = np.zeros((2, 0), dtype=int)
+    cloud = EllipseCloud(coef, mean, cov, k=0, nbd=nbd)
+    first = next(iter(cloud))
+    np.testing.assert_allclose(first, coef[0])
+
+
+def test_plot_creates_axes_and_patches():
+    coef = np.stack(
+        [
+            coef_from_axes([0.0, 0.0], 1.0, 1.0, 0.0),
+            coef_from_axes([1.0, 0.5], 1.5, 1.2, 0.3),
+        ],
+        axis=0,
+    )
+    mean = np.array([[0.0, 0.0], [1.0, 0.5]])
+    cov = np.stack([np.eye(2), np.eye(2)], axis=0)
+    nbd = np.zeros((2, 0), dtype=int)
+    cloud = EllipseCloud(coef, mean, cov, k=0, nbd=nbd)
+    ax = cloud.plot()
+    assert len(ax.patches) == 2
+    plt.close(ax.figure)
+
+
+def test_pdist_tangency_wrapper_matches_solver(rng):
+    cloud = random_cloud(rng, n_ellipses=4)
+    wrapper = cloud.pdist_tangency(backend="python", parallel=False)
+    direct = pdist_tangency(cloud, backend="python", parallel=False)
+    np.testing.assert_allclose(wrapper, direct)
 
 
 def test_str_method():

--- a/tests/test_geometry_edge_cases.py
+++ b/tests/test_geometry_edge_cases.py
@@ -1,0 +1,63 @@
+import numpy as np
+import pytest
+
+from ellphi.geometry import (
+    coef_from_cov,
+    infer_dim_from_coef_length,
+    pack_conic,
+    unpack_conic,
+    unpack_single_conic,
+)
+
+
+def test_infer_dim_from_coef_length_rejects_invalid_discriminant():
+    with pytest.raises(ValueError, match="symmetric quadratic form"):
+        infer_dim_from_coef_length(7)
+
+
+def test_pack_conic_requires_square_matrix():
+    matrix = np.zeros((2, 3))
+    linear = np.zeros(3)
+    with pytest.raises(ValueError, match="Quadratic matrices must have shape"):
+        pack_conic(matrix, linear, 0.0)
+
+
+def test_pack_conic_requires_linear_match():
+    matrix = np.eye(2)
+    linear = np.zeros(3)
+    with pytest.raises(ValueError, match="Linear term incompatible"):
+        pack_conic(matrix, linear, 0.0)
+
+
+def test_unpack_conic_rejects_invalid_rank():
+    coef = np.zeros((2, 2, 2))
+    with pytest.raises(ValueError, match="one- or two-dimensional"):
+        unpack_conic(coef)
+
+
+def test_unpack_single_conic_rejects_multiple_entries():
+    centers = np.array([[0.0, 0.0], [1.0, 1.0]])
+    covs = np.stack([np.eye(2), 2.0 * np.eye(2)])
+    coef = coef_from_cov(centers, covs)
+    with pytest.raises(ValueError, match="Expected coefficients for a single conic"):
+        unpack_single_conic(coef)
+
+
+@pytest.mark.parametrize(
+    "centers, covs, message",
+    [
+        (np.zeros((2, 2)), np.zeros((1, 2, 2)), "number of centres"),
+        (np.zeros((1, 2)), np.zeros((1, 2, 3)), "Covariance matrices must be square"),
+        (np.zeros((1, 3)), np.zeros((1, 2, 2)), "dimensionality"),
+    ],
+)
+def test_coef_from_cov_validates_shapes(centers, covs, message):
+    with pytest.raises(ValueError, match=message):
+        coef_from_cov(centers, covs)
+
+
+def test_coef_from_cov_singular_returns_nan():
+    center = np.array([0.0, 0.0])
+    cov = np.array([[1.0, 0.0], [0.0, 0.0]])
+    coef = coef_from_cov(center, cov)
+    assert np.isnan(coef).all()

--- a/tests/test_solver_dispatch_edge_cases.py
+++ b/tests/test_solver_dispatch_edge_cases.py
@@ -1,0 +1,51 @@
+import numpy as np
+import pytest
+
+import ellphi.solver as solver_mod
+from ellphi.geometry import coef_from_axes
+
+from .factories import random_cloud
+
+
+def test_extract_coef_array_requires_2d():
+    with pytest.raises(ValueError, match="shape"):
+        solver_mod._extract_coef_array(np.zeros(6))
+
+
+def test_should_use_cpp_rejects_unknown_backend():
+    with pytest.raises(ValueError, match="Unknown backend"):
+        solver_mod._should_use_cpp("unknown")
+
+
+def test_should_use_cpp_python_returns_false():
+    assert solver_mod._should_use_cpp("python") is False
+
+
+def test_should_use_cpp_requires_available_backend(monkeypatch):
+    monkeypatch.setattr(solver_mod._cpp, "is_available", lambda: False)
+    with pytest.raises(RuntimeError, match="C\\+\\+ backend requested"):
+        solver_mod._should_use_cpp("cpp")
+
+
+def test_normalize_method_rejects_unknown():
+    with pytest.raises(ValueError, match="Unknown method"):
+        solver_mod._normalize_method("not-a-method")
+
+
+def test_tangency_rejects_mismatched_coefficients():
+    p = np.zeros(6)
+    q = np.zeros(7)
+    with pytest.raises(ValueError, match="same length"):
+        solver_mod.tangency(p, q, backend="python")
+
+
+def test_tangency_rejects_unknown_backend():
+    p = coef_from_axes([0.0, 0.0], 1.0, 1.0, 0.0)
+    with pytest.raises(ValueError, match="Unknown backend"):
+        solver_mod.tangency(p, p, backend="unknown")
+
+
+def test_pdist_tangency_rejects_unknown_backend(rng):
+    cloud = random_cloud(rng, n_ellipses=2)
+    with pytest.raises(ValueError, match="Unknown backend"):
+        solver_mod.pdist_tangency(cloud, backend="unknown")

--- a/tests/test_solver_python_edge_cases.py
+++ b/tests/test_solver_python_edge_cases.py
@@ -110,6 +110,14 @@ def test_initial_mu_for_newton_defaults_on_all_nan_scores():
     assert mu == 0.5
 
 
+def test_initial_mu_for_newton_handles_exceptions():
+    def df(mu: float) -> float:
+        raise RuntimeError("boom")
+
+    mu = solver_py._initial_mu_for_newton(df)
+    assert mu == 0.5
+
+
 def test_initial_mu_for_newton_prefers_larger_gradient():
     def df(mu: float) -> float:
         return 1.0 if mu < 0.5 else 2.0
@@ -127,6 +135,30 @@ def test_solve_mu_brentq_newton_failsafe_uses_brentq(rng, monkeypatch):
 
     monkeypatch.setattr(solver_py, "scipy_newton", raise_newton)
     result = solver_py.solve_mu(p, q, method="brentq+newton", failsafe=True)
+    assert result == pytest.approx(expected)
+
+
+def test_solve_mu_brentq_newton_rejects_invalid_maxiter(rng):
+    p, q = random_coef_pair(rng)
+    with pytest.raises(ValueError, match="hybrid_bracket_maxiter"):
+        solver_py.solve_mu(
+            p, q, method="brentq+newton", hybrid_bracket_maxiter=0, x0=0.5
+        )
+    with pytest.raises(ValueError, match="hybrid_newton_maxiter"):
+        solver_py.solve_mu(
+            p, q, method="brentq+newton", hybrid_newton_maxiter=0, x0=0.5
+        )
+
+
+def test_solve_mu_brentq_newton_without_failsafe_returns_mu0(rng, monkeypatch):
+    p, q = random_coef_pair(rng)
+    expected = solver_py.solve_mu(p, q, method="brentq")
+
+    def fake_newton(*args, **kwargs):
+        return 0.123, SimpleNamespace(converged=False)
+
+    monkeypatch.setattr(solver_py, "scipy_newton", fake_newton)
+    result = solver_py.solve_mu(p, q, method="brentq+newton", failsafe=False)
     assert result == pytest.approx(expected)
 
 
@@ -179,6 +211,12 @@ def test_solve_mu_newton_nonconverged_without_failsafe_raises(rng, monkeypatch):
         solver_py.solve_mu(p, q, method="newton", x0=0.5, failsafe=False)
 
 
+def test_solve_mu_rejects_unknown_method(rng):
+    p, q = random_coef_pair(rng)
+    with pytest.raises(ValueError, match="Unknown method"):
+        solver_py.solve_mu(p, q, method="not-a-method")
+
+
 def test_solve_mu_rejects_nonfinite_target(monkeypatch, rng):
     p, q = random_coef_pair(rng)
     monkeypatch.setattr(solver_py, "_target", lambda mu, p, q: np.nan)
@@ -205,4 +243,11 @@ def test_pdist_tangency_serial_branch_matches_serial(rng):
     cloud = random_cloud(rng, n_ellipses=3)
     result = solver_py.pdist_tangency(cloud, parallel=False)
     expected = solver_py._pdist_tangency_serial(cloud)
+    np.testing.assert_allclose(result, expected)
+
+
+def test_pdist_tangency_parallel_branch_matches_parallel(rng):
+    cloud = random_cloud(rng, n_ellipses=3)
+    result = solver_py.pdist_tangency(cloud, parallel=True, n_jobs=1)
+    expected = solver_py._pdist_tangency_parallel(cloud, n_jobs=1)
     np.testing.assert_allclose(result, expected)

--- a/tests/test_solver_python_edge_cases.py
+++ b/tests/test_solver_python_edge_cases.py
@@ -1,0 +1,208 @@
+import numpy as np
+import pytest
+from types import SimpleNamespace
+
+import ellphi._solver_python as solver_py
+from ellphi.geometry import coef_from_axes
+
+from .factories import random_cloud, random_coef_pair
+
+
+def test_gaussian_elimination_requires_square_matrix():
+    matrix = np.zeros((2, 3))
+    rhs = np.zeros(2)
+    with pytest.raises(np.linalg.LinAlgError, match="square"):
+        solver_py._gaussian_elimination(matrix, rhs)
+
+
+def test_gaussian_elimination_detects_singular_pivot():
+    matrix = np.array([[0.0, 1.0], [0.0, 2.0]])
+    rhs = np.array([1.0, 2.0])
+    with pytest.raises(np.linalg.LinAlgError, match="singular"):
+        solver_py._gaussian_elimination(matrix, rhs)
+
+
+def test_gaussian_elimination_detects_zero_diagonal():
+    matrix = np.array([[1.0, 1.0], [2.0, 2.0]])
+    rhs = np.array([1.0, 2.0])
+    with pytest.raises(np.linalg.LinAlgError, match="singular"):
+        solver_py._gaussian_elimination(matrix, rhs)
+
+
+def test_quad_eval_dimension_mismatch():
+    coef = coef_from_axes([0.0, 0.0], 1.0, 1.0, 0.0)
+    with pytest.raises(ValueError, match="dimensionality"):
+        solver_py.quad_eval(coef, [0.0, 0.0, 0.0])
+
+
+def test_algsig_newton_nan_x0_fallback_converges():
+    def f(x: float) -> float:
+        return x - 0.5
+
+    def df(x: float) -> float:
+        return 1.0
+
+    result = solver_py._algsig_newton_py(f, df, np.nan, maxiter=3, xtol=1e-12, rtol=0.0)
+    assert result.converged
+    assert result.root == pytest.approx(0.5)
+
+
+def test_algsig_newton_nonfinite_target_returns_failure():
+    def f(x: float) -> float:
+        return np.nan
+
+    def df(x: float) -> float:
+        return 1.0
+
+    result = solver_py._algsig_newton_py(f, df, 0.5, maxiter=2, xtol=1e-12, rtol=0.0)
+    assert not result.converged
+
+
+def test_algsig_newton_zero_derivative_returns_failure():
+    def f(x: float) -> float:
+        return 1.0
+
+    def df(x: float) -> float:
+        return 0.0
+
+    result = solver_py._algsig_newton_py(f, df, 0.5, maxiter=2, xtol=1e-12, rtol=0.0)
+    assert not result.converged
+
+
+def test_algsig_newton_nonfinite_candidate_backtracks_and_fails():
+    def f(x: float) -> float:
+        return 1e308
+
+    def df(x: float) -> float:
+        return 1e-308
+
+    result = solver_py._algsig_newton_py(f, df, 0.5, maxiter=1, xtol=1e-12, rtol=0.0)
+    assert not result.converged
+
+
+def test_algsig_newton_stops_after_max_iterations():
+    def f(x: float) -> float:
+        return x - 0.25
+
+    def df(x: float) -> float:
+        return 1.0
+
+    result = solver_py._algsig_newton_py(f, df, 0.9, maxiter=1, xtol=0.0, rtol=0.0)
+    assert not result.converged
+
+
+def test_target_prime_returns_nan_when_pencil_build_fails(monkeypatch):
+    def raise_error(*args, **kwargs):
+        raise np.linalg.LinAlgError("boom")
+
+    monkeypatch.setattr(solver_py, "build_tangent_pencil", raise_error)
+    p = coef_from_axes([0.0, 0.0], 1.0, 1.0, 0.0)
+    q = coef_from_axes([1.0, 0.0], 1.0, 1.0, 0.0)
+    value = solver_py._target_prime(0.5, p, q)
+    assert np.isnan(value)
+
+
+def test_initial_mu_for_newton_defaults_on_all_nan_scores():
+    def df(mu: float) -> float:
+        return np.nan
+
+    mu = solver_py._initial_mu_for_newton(df)
+    assert mu == 0.5
+
+
+def test_initial_mu_for_newton_prefers_larger_gradient():
+    def df(mu: float) -> float:
+        return 1.0 if mu < 0.5 else 2.0
+
+    mu = solver_py._initial_mu_for_newton(df)
+    assert mu == pytest.approx(1.0 - 1e-5)
+
+
+def test_solve_mu_brentq_newton_failsafe_uses_brentq(rng, monkeypatch):
+    p, q = random_coef_pair(rng)
+    expected = solver_py.solve_mu(p, q, method="brentq")
+
+    def raise_newton(*args, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(solver_py, "scipy_newton", raise_newton)
+    result = solver_py.solve_mu(p, q, method="brentq+newton", failsafe=True)
+    assert result == pytest.approx(expected)
+
+
+def test_solve_mu_algsig_newton_failsafe_returns_brentq(rng, monkeypatch):
+    p, q = random_coef_pair(rng)
+    expected = solver_py.solve_mu(p, q, method="brentq")
+
+    monkeypatch.setattr(
+        solver_py,
+        "_algsig_newton_py",
+        lambda *args, **kwargs: solver_py.NewtonResult(0.5, False),
+    )
+
+    result = solver_py.solve_mu(p, q, method="algsig+newton", failsafe=True, x0=0.5)
+    assert result == pytest.approx(expected)
+
+
+def test_solve_mu_algsig_newton_without_failsafe_raises(rng, monkeypatch):
+    p, q = random_coef_pair(rng)
+    monkeypatch.setattr(
+        solver_py,
+        "_algsig_newton_py",
+        lambda *args, **kwargs: solver_py.NewtonResult(0.5, False),
+    )
+
+    with pytest.raises(RuntimeError, match="algsig\\+newton failed to converge"):
+        solver_py.solve_mu(p, q, method="algsig+newton", failsafe=False, x0=0.5)
+
+
+def test_solve_mu_newton_nonconverged_failsafe_returns_brentq(rng, monkeypatch):
+    p, q = random_coef_pair(rng)
+    expected = solver_py.solve_mu(p, q, method="brentq")
+
+    def fake_newton(*args, **kwargs):
+        return 0.123, SimpleNamespace(converged=False)
+
+    monkeypatch.setattr(solver_py, "scipy_newton", fake_newton)
+    result = solver_py.solve_mu(p, q, method="newton", x0=0.5, failsafe=True)
+    assert result == pytest.approx(expected)
+
+
+def test_solve_mu_newton_nonconverged_without_failsafe_raises(rng, monkeypatch):
+    p, q = random_coef_pair(rng)
+
+    def fake_newton(*args, **kwargs):
+        return 0.123, SimpleNamespace(converged=False)
+
+    monkeypatch.setattr(solver_py, "scipy_newton", fake_newton)
+    with pytest.raises(RuntimeError, match="Newton method failed to converge"):
+        solver_py.solve_mu(p, q, method="newton", x0=0.5, failsafe=False)
+
+
+def test_solve_mu_rejects_nonfinite_target(monkeypatch, rng):
+    p, q = random_coef_pair(rng)
+    monkeypatch.setattr(solver_py, "_target", lambda mu, p, q: np.nan)
+    with pytest.raises(RuntimeError, match="Non-finite target value"):
+        solver_py.solve_mu(p, q, method="newton", x0=0.5, failsafe=False)
+
+
+def test_tangency_rejects_mu_outside_bracket(monkeypatch):
+    p = coef_from_axes([0.0, 0.0], 1.0, 1.0, 0.0)
+    q = coef_from_axes([1.0, 0.0], 1.0, 1.0, 0.0)
+    monkeypatch.setattr(solver_py, "solve_mu", lambda *args, **kwargs: 2.0)
+    with pytest.raises(RuntimeError, match="within the bracket"):
+        solver_py.tangency(p, q, bracket=(0.0, 1.0))
+
+
+def test_pdist_tangency_parallel_returns_empty_for_single_ellipse(rng):
+    cloud = random_cloud(rng, n_ellipses=1)
+    result = solver_py._pdist_tangency_parallel(cloud)
+    assert result.shape == (0,)
+    assert result.dtype == float
+
+
+def test_pdist_tangency_serial_branch_matches_serial(rng):
+    cloud = random_cloud(rng, n_ellipses=3)
+    result = solver_py.pdist_tangency(cloud, parallel=False)
+    expected = solver_py._pdist_tangency_serial(cloud)
+    np.testing.assert_allclose(result, expected)


### PR DESCRIPTION
- Python Solver
  - [x] _gaussian_elimination（非正方/ゼロ pivot/対角 0）＋quad_eval 次元不一致 → tests/
    test_solver_python_edge_cases.py::test_gaussian_elimination_requires_square_matrix, tests/
    test_solver_python_edge_cases.py::test_gaussian_elimination_detects_singular_pivot, tests/
    test_solver_python_edge_cases.py::test_gaussian_elimination_detects_zero_diagonal, tests/
    test_solver_python_edge_cases.py::test_quad_eval_dimension_mismatch
  - [x] _algsig_newton_py 無効 x0 / 非有限 / 勾配 0 / バックトラック失敗 / 最大反復 → tests/
    test_solver_python_edge_cases.py::test_algsig_newton_nan_x0_fallback_converges, tests/
    test_solver_python_edge_cases.py::test_algsig_newton_nonfinite_target_returns_failure, tests/
    test_solver_python_edge_cases.py::test_algsig_newton_zero_derivative_returns_failure, tests/
    test_solver_python_edge_cases.py::test_algsig_newton_nonfinite_candidate_backtracks_and_fails, tests/
    test_solver_python_edge_cases.py::test_algsig_newton_stops_after_max_iterations
  - [x] _target_prime 例外→NaN と _initial_mu_for_newton の NaN/端点選択 → tests/
    test_solver_python_edge_cases.py::test_target_prime_returns_nan_when_pencil_build_fails, tests/
    test_solver_python_edge_cases.py::test_initial_mu_for_newton_defaults_on_all_nan_scores, tests/
    test_solver_python_edge_cases.py::test_initial_mu_for_newton_prefers_larger_gradient, tests/
    test_solver_python_edge_cases.py::test_initial_mu_for_newton_handles_exceptions
  - [x] solve_mu 不正 maxiter / 非有限値検知 / brentq+newton failsafe / algsig+newton failsafe・例外 /
    newton の x0 必須 / 未知 method / solve_single_stage の newton 分岐検討 → tests/
    test_solver_python_edge_cases.py::test_solve_mu_brentq_newton_rejects_invalid_maxiter, tests/
    test_solver_python_edge_cases.py::test_solve_mu_rejects_nonfinite_target, tests/
    test_solver_python_edge_cases.py::test_solve_mu_brentq_newton_failsafe_uses_brentq, tests/
    test_solver_python_edge_cases.py::test_solve_mu_brentq_newton_without_failsafe_returns_mu0, tests/
    test_solver_python_edge_cases.py::test_solve_mu_algsig_newton_failsafe_returns_brentq, tests/
    test_solver_python_edge_cases.py::test_solve_mu_algsig_newton_without_failsafe_raises, tests/
    test_basic.py::test_newton_requires_x0, tests/
    test_solver_python_edge_cases.py::test_solve_mu_rejects_unknown_method, src/ellphi/_solver_python.py
    に # pragma: no cover（solve_single_stage の newton 分岐は現状未使用）
  - [x] tangency の bracket 外/非有限 μ ガードと pdist_tangency 空入力/serial 分岐 → tests/
    test_solver_python_edge_cases.py::test_tangency_rejects_mu_outside_bracket, tests/
    test_solver_python_edge_cases.py::test_pdist_tangency_parallel_returns_empty_for_single_ellipse,
    tests/test_solver_python_edge_cases.py::test_pdist_tangency_serial_branch_matches_serial, tests/
    test_solver_python_edge_cases.py::test_pdist_tangency_parallel_branch_matches_parallel
  - [x] differentiable_solver 導関数ゼロ例外＋solver.py 入力/バックエンド/shape 検証 → tests/
    test_differentiable_solver.py::test_solve_mu_gradients_rejects_zero_derivative, tests/
    test_solver_dispatch_edge_cases.py::test_extract_coef_array_requires_2d, tests/
    test_solver_dispatch_edge_cases.py::test_should_use_cpp_rejects_unknown_backend, tests/
    test_solver_dispatch_edge_cases.py::test_should_use_cpp_requires_available_backend, tests/
    test_solver_dispatch_edge_cases.py::test_should_use_cpp_python_returns_false, tests/
    test_solver_dispatch_edge_cases.py::test_tangency_rejects_mismatched_coefficients, tests/
    test_solver_dispatch_edge_cases.py::test_tangency_rejects_unknown_backend, tests/
    test_solver_dispatch_edge_cases.py::test_pdist_tangency_rejects_unknown_backend（_should_use_cpp の
    auto 分岐は tests/test_solver.py::test_pdist_tangency_high_dimension で実行）
- C++ Backend
  - [x] _library_suffix/_expected_backend_version 分岐 → tests/
    test_cpp_backend_edge_cases.py::test_library_suffix_prefers_sysconfig, tests/
    test_cpp_backend_edge_cases.py::test_library_suffix_platform_fallback, tests/
    test_cpp_backend_edge_cases.py::test_expected_backend_version_uses_package_metadata, tests/
    test_cpp_backend_edge_cases.py::test_expected_backend_version_falls_back_on_missing_package
  - [x] _library_version シンボル欠落/空文字列 → tests/
    test_cpp_backend_edge_cases.py::test_library_version_requires_metadata, tests/
    test_cpp_backend_edge_cases.py::test_library_version_rejects_empty_value
  - [x] _validate_library_version 不一致 + _load_library 不在ファイル → tests/
    test_cpp_backend_edge_cases.py::test_validate_library_version_reports_mismatch, tests/
    test_cpp_backend_edge_cases.py::test_load_library_raises_on_missing_file
  - [x] _ensure_available エラーメッセージ + _raise_backend_error 例外振り分け → tests/
    test_cpp_backend_edge_cases.py::test_ensure_available_uses_error_message, tests/
    test_cpp_backend_edge_cases.py::test_ensure_available_defaults_message, tests/
    test_cpp_backend_edge_cases.py::test_raise_backend_error
  - [x] tangency/pdist_tangency 入力 shape バリデーション → tests/
    test_cpp_backend_edge_cases.py::test_tangency_rejects_non_1d_inputs, tests/
    test_cpp_backend_edge_cases.py::test_tangency_rejects_shape_mismatch, tests/
    test_cpp_backend_edge_cases.py::test_pdist_tangency_rejects_invalid_shape
- Geometry & Cloud
  - [x] infer_dim_from_coef_length 不正長さ（短すぎ/判別式不一致/無効次元） → tests/
    test_ellcloud.py::test_post_init_value_errors（短すぎ）, tests/
    test_geometry_edge_cases.py::test_infer_dim_from_coef_length_rejects_invalid_discriminant, src/ellphi/
    geometry.py に # pragma: no cover（無効次元ガードは防御的で到達不能）
  - [x] pack_conic 行列形状不正/線形項不整合、unpack_conic 不正次元、unpack_single_conic 複数入力 → tests/
    test_geometry_edge_cases.py::test_pack_conic_requires_square_matrix, tests/
    test_geometry_edge_cases.py::test_pack_conic_requires_linear_match, tests/
    test_geometry_edge_cases.py::test_unpack_conic_rejects_invalid_rank, tests/
    test_geometry_edge_cases.py::test_unpack_single_conic_rejects_multiple_entries
  - [x] coef_from_cov 入力不整合 + 特異共分散 → tests/
    test_geometry_edge_cases.py::test_coef_from_cov_validates_shapes, tests/
    test_geometry_edge_cases.py::test_coef_from_cov_singular_returns_nan
  - [x] EllipseCloud.__post_init__ 形状バリデーション + __iter__ → tests/
    test_ellcloud.py::test_post_init_value_errors, tests/
    test_ellcloud.py::test_post_init_validates_mean_shape, tests/
    test_ellcloud.py::test_post_init_validates_cov_shape, tests/
    test_ellcloud.py::test_post_init_validates_neighbourhood_shape, tests/
    test_ellcloud.py::test_iter_returns_coefficients
  - [x] EllipseCloud.plot（ax=None → 作成 + add_patch）と pdist_tangency ラッパー → tests/
    test_ellcloud.py::test_plot_creates_axes_and_patches, tests/
    test_ellcloud.py::test_pdist_tangency_wrapper_matches_solver
  - [x] __main__.py CLI エントリ → tests/test_cli.py::test_cli_module_entrypoint
- Misc (#89 にリストアップしていなかったもの)
  - [x] solve_mu の newton 失敗時の failsafe/非‑failsafe 挙動 → tests/
    test_solver_python_edge_cases.py::test_solve_mu_newton_nonconverged_failsafe_returns_brentq, tests/
    test_solver_python_edge_cases.py::test_solve_mu_newton_nonconverged_without_failsafe_raises
  - [x] _normalize_method の未知 method ガード → tests/
    test_solver_dispatch_edge_cases.py::test_normalize_method_rejects_unknown
  - [x] _library_version の bytes 文字列デコード → tests/
    test_cpp_backend_edge_cases.py::test_library_version_decodes_bytes