### PR TITLE
ci: add Windows wheel build and release workflows

### DIFF
--- a/.github/workflows/build-windows-wheels.yml
+++ b/.github/workflows/build-windows-wheels.yml
@@ -1,0 +1,80 @@
+name: Windows Wheels
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Poetry
+      run: pip install --upgrade poetry
+
+    - name: Build wheel
+      run: poetry build -f wheel
+
+    - name: Verify wheel contains binary
+      shell: pwsh
+      run: |
+        Add-Type -AssemblyName System.IO.Compression.FileSystem
+        $wheel = Get-ChildItem dist/*.whl | Select-Object -First 1
+        Write-Host "Inspecting $($wheel.Name)"
+        $zip = [System.IO.Compression.ZipFile]::OpenRead($wheel.FullName)
+        $entries = $zip.Entries | Where-Object { $_.Name -match '\.(pyd|dll)$' }
+        if ($entries.Count -eq 0) {
+          Write-Error "No .pyd or .dll found in wheel"
+          $zip.Dispose()
+          exit 1
+        }
+        $entries | ForEach-Object { Write-Host "Found: $($_.FullName)" }
+        $zip.Dispose()
+
+    - name: Smoke test — install and import
+      shell: pwsh
+      run: |
+        python -m venv test-env
+        test-env\Scripts\Activate.ps1
+        pip install (Get-ChildItem dist\*.whl).FullName
+        python -c "import ellphi; print('version:', ellphi.__version__)"
+        python -c "from ellphi.solver import has_cpp_backend; assert has_cpp_backend(), 'C++ backend not available'"
+        python -c "from ellphi.solver import build_info; print(build_info())"
+
+    - name: Smoke test — run solver
+      shell: pwsh
+      run: |
+        test-env\Scripts\Activate.ps1
+        python -c @"
+        import numpy as np
+        from ellphi import tangency, coef_from_cov
+        c1 = coef_from_cov(np.eye(2), np.array([0.0, 0.0]))
+        c2 = coef_from_cov(np.eye(2), np.array([3.0, 0.0]))
+        result = tangency(c1, c2)
+        print('tangency t =', result.t)
+        assert result.t > 0, 'Expected positive tangency time'
+        print('Solver smoke test passed.')
+        "@
+
+    - name: Upload wheel artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: wheel-windows-py${{ matrix.python-version }}
+        path: dist/*.whl
+        retention-days: 30

--- a/.github/workflows/build-windows-wheels.yml
+++ b/.github/workflows/build-windows-wheels.yml
@@ -64,8 +64,8 @@ jobs:
         python -c @"
         import numpy as np
         from ellphi import tangency, coef_from_cov
-        c1 = coef_from_cov(np.eye(2), np.array([0.0, 0.0]))
-        c2 = coef_from_cov(np.eye(2), np.array([3.0, 0.0]))
+        c1 = coef_from_cov(np.array([[0.0, 0.0]]), np.eye(2).reshape(1, 2, 2))
+        c2 = coef_from_cov(np.array([[3.0, 0.0]]), np.eye(2).reshape(1, 2, 2))
         result = tangency(c1, c2)
         print('tangency t =', result.t)
         assert result.t > 0, 'Expected positive tangency time'

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12"]
     env:
       ELLPHI_USE_EIGEN: "1"
       ELLPHI_EIGEN_INCLUDE: "/usr/include/eigen3"
@@ -26,7 +26,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: "pip"
@@ -39,7 +39,7 @@ jobs:
       run: pip install --upgrade poetry
 
     - name: Cache Poetry env
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pypoetry
         key: ${{ runner.os }}-poetry-${{ hashFiles('pyproject.toml') }}-v2
@@ -73,7 +73,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
         cache: "pip"
@@ -85,7 +85,7 @@ jobs:
       run: pip install --upgrade poetry
 
     - name: Cache Poetry env
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pypoetry
         key: ${{ runner.os }}-poetry-${{ hashFiles('pyproject.toml') }}-v2
@@ -108,7 +108,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
         cache: "pip"
@@ -163,7 +163,7 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.11"
         cache: "pip"
@@ -172,7 +172,7 @@ jobs:
       run: pip install --upgrade poetry
 
     - name: Cache Poetry env
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: ~/.cache/pypoetry
         key: ${{ runner.os }}-poetry-${{ hashFiles('pyproject.toml') }}-v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,32 @@
+# Release workflow — publishes to PyPI or TestPyPI based on tag name.
+#
+# Routing:
+#   v*.dev*  → TestPyPI (publish-testpypi job)
+#   v*.*.*   → PyPI     (publish-pypi job)
+#
+# Prerequisites (one-time setup):
+#
+# 1. GitHub Environments (Settings → Environments):
+#    - "pypi"     — Deployment tags: v[0-9]*.[0-9]*.[0-9]*
+#                    and v[0-9]*.[0-9]*.[0-9]*.post[0-9]*
+#                    Optional: add Required reviewers for release approval.
+#    - "testpypi" — Deployment tags: v* (allow all)
+#
+# 2. PyPI Trusted Publishing (pypi.org → ellphi → Publishing):
+#    Owner: t-uda, Repository: ellphi,
+#    Workflow: release.yml, Environment: pypi
+#
+# 3. TestPyPI Trusted Publishing (test.pypi.org → ellphi → Publishing):
+#    Owner: t-uda, Repository: ellphi,
+#    Workflow: release.yml, Environment: testpypi
+#
+# Tag examples:
+#   v0.1.2       → PyPI
+#   v0.1.2.post1 → PyPI
+#   v0.1.2.dev1  → TestPyPI
+#   v0.1.2a1     → blocked by "pypi" environment tag rule → manual decision
+#   v0.1.2rc1    → blocked by "pypi" environment tag rule → manual decision
+
 name: Release
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -84,7 +84,31 @@ jobs:
         name: dist-windows-py${{ matrix.python-version }}
         path: dist/*.whl
 
-  publish:
+  publish-testpypi:
+    if: contains(github.ref_name, 'dev')
+    needs: [build-sdist, build-linux, build-windows]
+    runs-on: ubuntu-latest
+    environment: testpypi
+    permissions:
+      id-token: write
+    steps:
+    - name: Download all artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: dist
+        merge-multiple: true
+
+    - name: List distribution files
+      run: ls -la dist/
+
+    - name: Publish to TestPyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        packages-dir: dist/
+
+  publish-pypi:
+    if: ${{ !contains(github.ref_name, 'dev') }}
     needs: [build-sdist, build-linux, build-windows]
     runs-on: ubuntu-latest
     environment: pypi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,106 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+
+jobs:
+  build-sdist:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Install Poetry
+      run: pip install --upgrade poetry
+
+    - name: Build sdist
+      run: poetry build -f sdist
+
+    - name: Upload sdist
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist-sdist
+        path: dist/*.tar.gz
+
+  build-linux:
+    runs-on: ubuntu-latest
+    env:
+      ELLPHI_USE_EIGEN: "1"
+      ELLPHI_EIGEN_INCLUDE: "/usr/include/eigen3"
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Install Eigen headers
+      run: sudo apt-get update && sudo apt-get install -y libeigen3-dev
+
+    - name: Install Poetry
+      run: pip install --upgrade poetry
+
+    - name: Build wheel
+      run: poetry build -f wheel
+
+    - name: Upload wheel
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist-linux
+        path: dist/*.whl
+
+  build-windows:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12"]
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Poetry
+      run: pip install --upgrade poetry
+
+    - name: Build wheel
+      run: poetry build -f wheel
+
+    - name: Upload wheel
+      uses: actions/upload-artifact@v4
+      with:
+        name: dist-windows-py${{ matrix.python-version }}
+        path: dist/*.whl
+
+  publish:
+    needs: [build-sdist, build-linux, build-windows]
+    runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+    - name: Download all artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: dist
+        merge-multiple: true
+
+    - name: List distribution files
+      run: ls -la dist/
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        packages-dir: dist/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,32 @@ Finalize the content right before release.
    - bump to the release version (e.g., `0.1.2`)
    - run all required local checks
    - merge into `main`
-   - tag the release and publish
+   - tag the release and push the tag
+
+## Publishing
+
+Releases are published automatically by the CI release workflow
+(`.github/workflows/release.yml`).
+
+| Tag | Destination |
+|-----|-------------|
+| `v0.1.2.dev1` | TestPyPI |
+| `v0.1.2` | PyPI |
+| `v0.1.2.post1` | PyPI |
+| `v0.1.2a1`, `v0.1.2rc1` | Blocked by environment rule — manual decision |
+
+```bash
+# Example: publish a dev build to TestPyPI
+git tag v0.1.2.dev1
+git push origin v0.1.2.dev1
+
+# Example: publish a release to PyPI
+git tag v0.1.2
+git push origin v0.1.2
+```
+
+The workflow uses PyPI Trusted Publishing (no API tokens needed).
+See the comments at the top of `release.yml` for one-time setup steps.
 
 ## Required Local Checks
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,11 @@
 ## Unreleased
 
+### CI
+
+- Added Windows wheel build workflow (`win_amd64`, Python 3.10–3.12).
+- Added release workflow for PyPI publishing via Trusted Publishing.
+- Added Python 3.12 to the CI test matrix.
+
 ### Documentation
 
 - Expanded MkDocs site: added Notebook Examples page to User Guide, listing


### PR DESCRIPTION
## Summary
- Add `build-windows-wheels.yml`: builds `win_amd64` wheels for Python 3.10/3.11/3.12 with smoke tests (import, C++ backend check, solver run) on every push to `main` / PR
- Add `release.yml`: builds sdist + Linux/Windows wheels and publishes to PyPI via Trusted Publishing on `v*` tags
- Update `python-app.yml`: add Python 3.12 to test matrix, bump `actions/setup-python` to v5 and `actions/cache` to v4

## Prerequisites
- Configure [Trusted Publishing](https://docs.pypi.org/trusted-publishers/) on pypi.org for `t-uda/ellphi` → `release.yml`
- Create a `pypi` GitHub environment with optional protection rules

## Test plan
- [x] `build-windows-wheels` workflow passes on this PR (3 matrix jobs)
- [x] Existing `CI` workflow passes with Python 3.12 added
- [x] Download Windows wheel artifact and verify `.pyd` is included
- [x] (Future) Test `release.yml` with TestPyPI using a dev tag

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)