### PR TITLE
contrib: add agent-skill for AI agent integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,9 @@
 # Gemini
 .gemini/
 GEMINI.md
+# Claude
+.claude/
+CLAUDE.md
 # Serena AI Helper
 .serena/
 

--- a/contrib/agent-skill/SKILL.md
+++ b/contrib/agent-skill/SKILL.md
@@ -1,0 +1,88 @@
+---
+name: ellphi-api
+description: >
+  EllPHi library usage guide for anisotropic persistent homology.
+  Use when: (1) writing code that imports ellphi, (2) working with
+  anisotropic persistent homology or ellipsoid tangency distances,
+  (3) debugging ellphi solver issues or understanding coefficient format.
+---
+
+# EllPHi API Skill
+
+## Version check
+
+```bash
+python -c "import ellphi; print(ellphi.__version__)"
+```
+
+Require >= 0.1.2 for the `grad` module. If older: `pip install -U ellphi`.
+
+## Core concepts
+
+### Ellipsoid coefficient format
+
+Each ellipsoid is a quadratic `Q(x) = x^T A x + 2 b^T x + c`, packed into a flat vector of length `m = (d+1)(d+2)/2` (m=6 for d=2, m=10 for d=3). Packing order: upper-triangular A, then b (length d), then c (scalar).
+
+**Critical: b = -A x_bar** (negative sign). To recover center: `x_bar = -A^{-1} b`. Use `unpack_conic` to extract (A, b, c).
+
+### Tangency distance
+
+The inflation factor `t` at which two ellipsoids become externally tangent. The solver finds pencil parameter `mu` in [0,1] minimizing the discriminant, then `t = sqrt(alpha)`.
+
+## Quick recipe: point cloud to PH
+
+```python
+import ellphi
+
+cloud = ellphi.ellipse_cloud(X, k=5)   # X: (N, d) point cloud
+dists = ellphi.pdist_tangency(cloud)    # condensed distance matrix (like scipy pdist)
+
+# Feed to ripser, GUDHI, etc.
+```
+
+## Quick recipe: gradient optimization
+
+```python
+from ellphi.grad import pdist_tangency_grad
+
+dists, vjp = pdist_tangency_grad(cloud.coef)  # cloud.coef: (N, m)
+grad_coefs = vjp(upstream_grad)                # upstream: (N*(N-1)//2,) -> (N, m)
+```
+
+## Solver methods
+
+Pass `method=` to `tangency()`:
+
+| Method | Notes |
+|--------|-------|
+| `"brentq+newton"` | **(default)** Brentq bracketing + Newton polish |
+| `"brentq"` | Pure Brentq. Robust, slower |
+| `"bisect"` | Most robust, slowest |
+| `"newton"` | Requires `x0`. Fast but can diverge |
+
+## Backends
+
+`backend=` in `tangency()` / `pdist_tangency()`: `"auto"` (default, C++ if available), `"python"`, `"cpp"`.
+
+## Common pitfalls
+
+1. **b sign**: `b = -A x_bar`. Forgetting the negative sign is the #1 bug.
+2. **Condensed distances**: `pdist_tangency` returns 1-D like `scipy.spatial.distance.pdist`. Use `squareform` for a full matrix.
+3. **Degenerate inputs**: `tangency_grad` raises `ZeroDivisionError` for identical/concentric ellipsoids.
+4. **Singular covariance**: `coef_from_cov` returns NaN for singular matrices.
+
+## Envelope theorem (grad module)
+
+See [references/grad_module.md](references/grad_module.md) for how the envelope theorem enables efficient exact gradients.
+
+## API details
+
+For full function signatures and parameters:
+
+```bash
+python -c "import ellphi; help(ellphi.tangency)"
+python -c "from ellphi.grad import tangency_grad; help(tangency_grad)"
+```
+
+- Current exports: `src/ellphi/__init__.py`
+- Full reference: the project's MkDocs site (`mkdocs serve` or published docs)

--- a/contrib/agent-skill/references/grad_module.md
+++ b/contrib/agent-skill/references/grad_module.md
@@ -8,8 +8,8 @@ The tangency distance `t` depends on coefficient vectors `p` and `q` through:
 2. The tangent point `x*(mu*)`, the pencil ellipsoid center at `mu*`.
 
 By the envelope theorem, at the optimum `mu*`, the derivative of the
-objective w.r.t. `mu` is zero. So `dt/dp` depends only on the **explicit**
-dependence of the pencil on `p`, not on the chain through `mu*(p)`:
+tangent point `x*(mu*)` w.r.t. `p` drops out of the gradient formula.
+The `d_mu/dp` terms remain (computed via implicit differentiation):
 
 ```
 dt/dp_i = (1/(2t)) * [(1 - mu*) * base_i + scalar * d_mu/dp_i]

--- a/contrib/agent-skill/references/grad_module.md
+++ b/contrib/agent-skill/references/grad_module.md
@@ -1,0 +1,36 @@
+# EllPHi Grad Module — Conceptual Background
+
+## Envelope theorem approach
+
+The tangency distance `t` depends on coefficient vectors `p` and `q` through:
+
+1. The pencil parameter `mu*` (optimal blend), itself a function of (p, q).
+2. The tangent point `x*(mu*)`, the pencil ellipsoid center at `mu*`.
+
+By the envelope theorem, at the optimum `mu*`, the derivative of the
+objective w.r.t. `mu` is zero. So `dt/dp` depends only on the **explicit**
+dependence of the pencil on `p`, not on the chain through `mu*(p)`:
+
+```
+dt/dp_i = (1/(2t)) * [(1 - mu*) * base_i + scalar * d_mu/dp_i]
+dt/dq_i = (1/(2t)) * [mu* * base_i + scalar * d_mu/dq_i]
+```
+
+where `base` is the monomial basis at the tangent point, and
+`scalar = base . (q - p)`.
+
+The `d_mu/dp` terms come from implicit differentiation of the optimality
+condition `F(mu, p, q) = 0` (handled internally by `solve_mu_gradients`
+in `ellphi.differentiable_solver`).
+
+## Key design points
+
+- `tangency_grad` / `pdist_tangency_grad` are the public API (in `ellphi.grad`).
+- They handle the full chain: mu gradients -> t gradients, including the
+  `1/(2t)` factor and monomial basis evaluation.
+- `pdist_tangency_grad` returns a VJP (vector-Jacobian product) pullback that
+  accumulates pair contributions into per-ellipsoid gradients.
+- Degenerate configurations (identical/concentric ellipsoids) raise
+  `ZeroDivisionError` because the implicit function theorem breaks down.
+
+For function signatures: `python -c "from ellphi.grad import tangency_grad; help(tangency_grad)"`


### PR DESCRIPTION
## Summary
- Add `contrib/agent-skill/` with SKILL.md and references/grad_module.md
- Teaches AI agents EllPHi's coefficient format, tangency distance concept, PH pipeline recipe, gradient optimization recipe, and common pitfalls
- Install via symlink: `ln -s .../contrib/agent-skill ~/.claude/skills/ellphi-api`

## Design
- **Hybrid approach**: core concepts and recipes are static in SKILL.md (~88 lines); full API signatures are delegated to `help()`, source, and MkDocs (no duplication)
- **Progressive disclosure**: envelope theorem details in `references/grad_module.md`, loaded only when needed
- Framework-agnostic naming (`agent-skill`, not `claude-skill`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)