### PR TITLE
Add coef_from_cov_grad: differentiable geometry with VJP

### DIFF
--- a/contrib/agent-skill/SKILL.md
+++ b/contrib/agent-skill/SKILL.md
@@ -46,7 +46,24 @@ dists = ellphi.pdist_tangency(cloud)    # condensed distance matrix (like scipy 
 from ellphi.grad import pdist_tangency_grad
 
 dists, vjp = pdist_tangency_grad(cloud.coef)  # cloud.coef: (N, m)
-grad_coefs = vjp(upstream_grad)                # upstream: (N*(N-1)//2,) -> (N, m)
+grad_coefs = vjp(upstream_grad)               # upstream: (N*(N-1)//2,) -> (N, m)
+```
+
+### End-to-end: centers + covariances → loss
+
+```python
+from ellphi.grad import coef_from_cov_grad, pdist_tangency_grad
+
+# Forward + VJP for coef_from_cov
+coefs, vjp_coef = coef_from_cov_grad(centers, covs)
+
+# Forward + VJP for tangency distances
+dists, vjp_dist = pdist_tangency_grad(coefs)
+
+# Backward: chain the two VJPs
+loss = dists.sum()
+grad_coefs = vjp_dist(np.ones_like(dists))    # (N, m)
+grad_centers, grad_covs = vjp_coef(grad_coefs) # (N,d), (N,d,d)
 ```
 
 ## Solver methods

--- a/contrib/agent-skill/references/grad_module.md
+++ b/contrib/agent-skill/references/grad_module.md
@@ -23,6 +23,19 @@ The `d_mu/dp` terms come from implicit differentiation of the optimality
 condition `F(mu, p, q) = 0` (handled internally by `solve_mu_gradients`
 in `ellphi.differentiable_solver`).
 
+## coef_from_cov_grad: differentiable geometry
+
+`coef_from_cov_grad(X, cov, *, scale)` is the differentiable version of
+`coef_from_cov`. It returns `(coefs, vjp)` where the VJP maps
+`grad_coefs (N, m)` back to `(grad_centers (N, d), grad_cov (N, d, d))`.
+
+Internally it uses the matrix inverse derivative identity:
+`d(Σ⁻¹) = -Σ⁻¹ dΣ Σ⁻¹` to propagate gradients through `A = Σ⁻¹/s²`.
+
+Combined with `pdist_tangency_grad`, this enables end-to-end gradient
+computation from geometric parameters (centers, covariances) through to
+a topological loss, without finite differences.
+
 ## Key design points
 
 - `tangency_grad` / `pdist_tangency_grad` are the public API (in `ellphi.grad`).
@@ -30,6 +43,8 @@ in `ellphi.differentiable_solver`).
   `1/(2t)` factor and monomial basis evaluation.
 - `pdist_tangency_grad` returns a VJP (vector-Jacobian product) pullback that
   accumulates pair contributions into per-ellipsoid gradients.
+- `coef_from_cov_grad` completes the chain by differentiating through
+  the (centers, covs) → coefs mapping. Works for arbitrary dimension d.
 - Degenerate configurations (identical/concentric ellipsoids) raise
   `ZeroDivisionError` because the implicit function theorem breaks down.
 

--- a/src/ellphi/__init__.py
+++ b/src/ellphi/__init__.py
@@ -44,7 +44,7 @@ from .solver import (
 )
 
 
-from .grad import TangencyGrad, tangency_grad, pdist_tangency_grad
+from .grad import TangencyGrad, tangency_grad, pdist_tangency_grad, coef_from_cov_grad
 
 FloatArray = NDArray[np.float64]
 
@@ -74,6 +74,7 @@ __all__ = [
     "TangencyGrad",
     "tangency_grad",
     "pdist_tangency_grad",
+    "coef_from_cov_grad",
     "__version__",
     "version_info",
 ]

--- a/src/ellphi/__init__.pyi
+++ b/src/ellphi/__init__.pyi
@@ -29,6 +29,7 @@ from .grad import (
     TangencyGrad as TangencyGrad,
     tangency_grad as tangency_grad,
     pdist_tangency_grad as pdist_tangency_grad,
+    coef_from_cov_grad as coef_from_cov_grad,
 )
 from ._version import __version__ as __version__
 
@@ -55,6 +56,7 @@ __all__ = [
     "TangencyGrad",
     "tangency_grad",
     "pdist_tangency_grad",
+    "coef_from_cov_grad",
     "FloatArray",
     "__version__",
     "version_info",

--- a/src/ellphi/grad.py
+++ b/src/ellphi/grad.py
@@ -1,7 +1,8 @@
-"""Differentiable tangency distances for gradient-based optimisation.
+"""Differentiable tangency distances and geometry helpers for gradient-based optimisation.
 
-This module exposes ``tangency_grad`` (single-pair gradient) and
-``pdist_tangency_grad`` (batch pairwise, with VJP pullback).
+This module exposes ``tangency_grad`` (single-pair gradient),
+``pdist_tangency_grad`` (batch pairwise, with VJP pullback), and
+``coef_from_cov_grad`` (differentiable coefficient computation).
 """
 
 from __future__ import annotations
@@ -15,7 +16,7 @@ import numpy as np
 from .differentiable_solver import solve_mu_gradients
 from .solver import tangency
 
-__all__ = ["TangencyGrad", "tangency_grad", "pdist_tangency_grad"]
+__all__ = ["TangencyGrad", "tangency_grad", "pdist_tangency_grad", "coef_from_cov_grad"]
 
 
 @dataclasses.dataclass(slots=True, frozen=True)
@@ -144,3 +145,103 @@ def pdist_tangency_grad(
         return g_coefs
 
     return dists, vjp
+
+
+def coef_from_cov_grad(
+    X: np.ndarray,
+    cov: np.ndarray,
+    /,
+    *,
+    scale: float = 1.0,
+) -> tuple[np.ndarray, Callable[[np.ndarray], tuple[np.ndarray, np.ndarray]]]:
+    """Converts centers and covariances to packed conic coefficients, with VJP.
+
+    This is the differentiable version of ``coef_from_cov``. It returns the same
+    coefficient array plus a VJP (vector-Jacobian product) pullback function.
+
+    Args:
+        X: Centers array, shape ``(n, d)`` or ``(d,)``.
+        cov: Covariance matrices, shape ``(n, d, d)`` or ``(d, d)``.
+        scale: Optional scaling factor for covariance matrices.
+
+    Returns:
+        A tuple ``(coefs, vjp)`` where:
+
+        - ``coefs``: shape ``(n, m)``, same as ``coef_from_cov`` output
+        - ``vjp``: callable ``(grad_coefs,) -> (grad_X, grad_cov)`` where
+          ``grad_X`` has shape ``(n, d)`` and ``grad_cov`` has shape ``(n, d, d)``
+    """
+    from .geometry import coef_from_cov, pack_conic
+
+    centers = np.asarray(X, dtype=float)
+    cov_arr = np.asarray(cov, dtype=float)
+
+    if centers.ndim == 1:
+        centers = centers[np.newaxis, :]
+    if cov_arr.ndim == 2:
+        cov_arr = cov_arr[np.newaxis, :, :]
+
+    n, d = centers.shape
+    s2 = scale**2
+
+    # Forward pass
+    inv_cov = np.linalg.inv(cov_arr)  # (n, d, d)
+    A = inv_cov / s2  # (n, d, d)
+    b = -np.einsum("nij,nj->ni", A, centers)  # (n, d)
+    c = np.einsum("ni,nij,nj->n", centers, A, centers)  # (n,)
+
+    coefs = pack_conic(A, b, c)
+
+    # Precompute indices for unpacking
+    tri_i, tri_j = np.triu_indices(d)
+    n_quad = tri_i.size
+
+    def vjp(
+        grad_coefs: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        gc = np.asarray(grad_coefs, dtype=float)
+
+        # Unpack grad_coefs into grad_A_packed, grad_b, grad_c
+        grad_A_packed = gc[:, :n_quad]  # (n, n_quad)
+        grad_b = gc[:, n_quad : n_quad + d]  # (n, d)
+        grad_c = gc[:, n_quad + d]  # (n,)
+
+        # Reconstruct grad_A from upper-tri packed entries.
+        # pack_conic extracts A[tri_i, tri_j] (upper triangle only), so
+        # the gradient from packing only touches those entries.
+        grad_A = np.zeros((n, d, d), dtype=float)
+        grad_A[:, tri_i, tri_j] = grad_A_packed
+
+        # Accumulate contributions from b = -A @ center into grad_A.
+        # b_k = -sum_j A[k,j] * center[j], so dL/dA[k,j] += -grad_b[k]*center[j]
+        # This contribution is for the FULL matrix (not just upper triangle).
+        grad_A += -np.einsum("ni,nj->nij", grad_b, centers)
+
+        # Accumulate contributions from c = center^T A center into grad_A.
+        # c = sum_{i,j} center[i] A[i,j] center[j], so
+        # dL/dA[i,j] += grad_c * center[i] * center[j]
+        grad_A += grad_c[:, None, None] * np.einsum("ni,nj->nij", centers, centers)
+
+        # --- grad w.r.t. centers ---
+        # From b = -A @ center: grad_center += -A^T @ grad_b
+        grad_centers = -np.einsum("nji,nj->ni", A, grad_b)
+        # From c = center^T A center: grad_center += 2 * A @ center * grad_c
+        #   = -2 * b * grad_c
+        grad_centers += -2.0 * b * grad_c[:, None]
+
+        # --- grad w.r.t. cov (via A = inv(cov)/s^2) ---
+        # A = inv(cov) / s^2
+        # dA = -inv(cov) @ dCov @ inv(cov) / s^2
+        # <grad_A, dA> = tr(grad_A^T (-inv(cov) dCov inv(cov) / s^2))
+        #              = -1/s^2 * tr(inv(cov)^T grad_A^T inv(cov)^T dCov)
+        # Since inv(cov) is symmetric:
+        #   grad_cov = -inv(cov) @ grad_A^T @ inv(cov) / s^2
+        #            = -s^2 A @ grad_A^T @ s^2 A / s^2
+        #            = -s^2 * A @ grad_A^T @ A
+        # A @ grad_A^T @ A: note grad_A^T[i,j] = grad_A[j,i]
+        grad_A_T = np.swapaxes(grad_A, -2, -1)
+        grad_cov = -s2 * np.einsum("nij,njk,nkl->nil", A, grad_A_T, A)
+
+        return grad_centers, grad_cov
+
+    return coefs, vjp

--- a/src/ellphi/grad.py
+++ b/src/ellphi/grad.py
@@ -1,4 +1,6 @@
-"""Differentiable tangency distances and geometry helpers for gradient-based optimisation.
+"""Differentiable tangency distances and geometry helpers.
+
+Gradient-based optimisation support for ellphi.
 
 This module exposes ``tangency_grad`` (single-pair gradient),
 ``pdist_tangency_grad`` (batch pairwise, with VJP pullback), and
@@ -171,7 +173,7 @@ def coef_from_cov_grad(
         - ``vjp``: callable ``(grad_coefs,) -> (grad_X, grad_cov)`` where
           ``grad_X`` has shape ``(n, d)`` and ``grad_cov`` has shape ``(n, d, d)``
     """
-    from .geometry import coef_from_cov, pack_conic
+    from .geometry import pack_conic
 
     centers = np.asarray(X, dtype=float)
     cov_arr = np.asarray(cov, dtype=float)

--- a/tests/test_coef_from_cov_grad.py
+++ b/tests/test_coef_from_cov_grad.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import numpy as np
-import pytest
 
 from ellphi import coef_from_cov_grad
 from ellphi.geometry import coef_from_cov

--- a/tests/test_coef_from_cov_grad.py
+++ b/tests/test_coef_from_cov_grad.py
@@ -1,0 +1,188 @@
+"""Tests for ellphi.grad.coef_from_cov_grad."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from ellphi import coef_from_cov_grad
+from ellphi.geometry import coef_from_cov
+
+from .factories import random_covariance
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _numerical_jacobian_X(centers, covs, scale, h=1e-6):
+    """Central FD Jacobian of coef_from_cov w.r.t. centers."""
+    n, d = centers.shape
+    coefs0 = coef_from_cov(centers, covs, scale=scale)
+    m = coefs0.shape[-1]
+    jac = np.zeros((n, m, n, d))
+    for i in range(n):
+        for j in range(d):
+            X_plus = centers.copy()
+            X_plus[i, j] += h
+            X_minus = centers.copy()
+            X_minus[i, j] -= h
+            c_plus = coef_from_cov(X_plus, covs, scale=scale)
+            c_minus = coef_from_cov(X_minus, covs, scale=scale)
+            jac[:, :, i, j] = (c_plus - c_minus) / (2 * h)
+    return jac
+
+
+def _numerical_jacobian_cov(centers, covs, scale, h=1e-6):
+    """Central FD Jacobian of coef_from_cov w.r.t. cov entries.
+
+    Perturbs each entry of the symmetric covariance matrix while maintaining
+    symmetry. For the symmetric parameterization, we perturb both (j,k) and
+    (k,j) together and assign the derivative to both entries.
+    """
+    n, d = centers.shape
+    coefs0 = coef_from_cov(centers, covs, scale=scale)
+    m = coefs0.shape[-1]
+    jac = np.zeros((n, m, n, d, d))
+    for i in range(n):
+        for j in range(d):
+            for k in range(j, d):
+                cov_plus = covs.copy()
+                cov_plus[i, j, k] += h
+                cov_plus[i, k, j] += h  # keep symmetric (no-op when j==k)
+                cov_minus = covs.copy()
+                cov_minus[i, j, k] -= h
+                cov_minus[i, k, j] -= h
+                c_plus = coef_from_cov(centers, cov_plus, scale=scale)
+                c_minus = coef_from_cov(centers, cov_minus, scale=scale)
+                deriv = (c_plus - c_minus) / (2 * h)
+                jac[:, :, i, j, k] = deriv
+                jac[:, :, i, k, j] = deriv
+    return jac
+
+
+def _check_vjp_against_fd(centers, covs, scale, rng):
+    """Check VJP matches numerical Jacobian for given inputs."""
+    n, d = centers.shape
+
+    coefs, vjp = coef_from_cov_grad(centers, covs, scale=scale)
+    m = coefs.shape[-1]
+
+    # Check forward pass matches coef_from_cov
+    ref = coef_from_cov(centers, covs, scale=scale)
+    np.testing.assert_allclose(coefs, ref, atol=1e-12)
+
+    # Random upstream gradient
+    g_coefs = rng.standard_normal((n, m))
+    grad_X, grad_cov = vjp(g_coefs)
+
+    # --- Check grad_X via FD ---
+    jac_X = _numerical_jacobian_X(centers, covs, scale)
+    # Expected grad_X[i, j] = sum over (a, b) of g_coefs[a, b] * jac_X[a, b, i, j]
+    expected_grad_X = np.einsum("ab,abij->ij", g_coefs, jac_X)
+    np.testing.assert_allclose(grad_X, expected_grad_X, rtol=1e-5, atol=1e-8)
+
+    # --- Check grad_cov via FD ---
+    # The FD perturbs both (j,k) and (k,j) together (symmetric perturbation),
+    # so the FD derivative is grad_cov[j,k] + grad_cov[k,j]. We symmetrize
+    # our VJP output before comparing.
+    jac_cov = _numerical_jacobian_cov(centers, covs, scale)
+    expected_grad_cov = np.einsum("ab,abijk->ijk", g_coefs, jac_cov)
+    grad_cov_sym = grad_cov + np.swapaxes(grad_cov, -2, -1)
+    np.testing.assert_allclose(grad_cov_sym, expected_grad_cov, rtol=1e-5, atol=1e-8)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_forward_matches_coef_from_cov_d2(rng):
+    """Forward pass matches coef_from_cov for d=2."""
+    centers = rng.uniform(-5, 5, size=(3, 2))
+    covs = np.stack([random_covariance(rng, dim=2) for _ in range(3)])
+    coefs, _ = coef_from_cov_grad(centers, covs)
+    ref = coef_from_cov(centers, covs)
+    np.testing.assert_allclose(coefs, ref, atol=1e-12)
+
+
+def test_vjp_d2_identity_cov(rng):
+    """VJP correct for d=2 with identity covariance."""
+    centers = rng.uniform(-5, 5, size=(2, 2))
+    covs = np.stack([np.eye(2)] * 2)
+    _check_vjp_against_fd(centers, covs, scale=1.0, rng=rng)
+
+
+def test_vjp_d2_random_cov(rng):
+    """VJP correct for d=2 with random covariances."""
+    centers = rng.uniform(-5, 5, size=(3, 2))
+    covs = np.stack([random_covariance(rng, dim=2) for _ in range(3)])
+    _check_vjp_against_fd(centers, covs, scale=1.0, rng=rng)
+
+
+def test_vjp_d3(rng):
+    """VJP correct for d=3."""
+    centers = rng.uniform(-5, 5, size=(2, 3))
+    covs = np.stack([random_covariance(rng, dim=3) for _ in range(2)])
+    _check_vjp_against_fd(centers, covs, scale=1.0, rng=rng)
+
+
+def test_vjp_rotated_cov(rng):
+    """VJP correct for non-identity covariance with rotation (d=2)."""
+    angle = rng.uniform(0, np.pi)
+    cos, sin = np.cos(angle), np.sin(angle)
+    rot = np.array([[cos, -sin], [sin, cos]])
+    diag = np.diag([3.0, 0.5])
+    cov = rot @ diag @ rot.T
+
+    centers = rng.uniform(-5, 5, size=(2, 2))
+    covs = np.stack([cov, cov])
+    _check_vjp_against_fd(centers, covs, scale=1.0, rng=rng)
+
+
+def test_vjp_with_scale(rng):
+    """VJP correct for non-unit scale values."""
+    centers = rng.uniform(-5, 5, size=(2, 2))
+    covs = np.stack([random_covariance(rng, dim=2) for _ in range(2)])
+    for scale in [0.5, 2.0, 3.7]:
+        _check_vjp_against_fd(centers, covs, scale=scale, rng=rng)
+
+
+def test_vjp_single_ellipsoid(rng):
+    """VJP works for a single ellipsoid (d,) input."""
+    center = rng.uniform(-5, 5, size=(2,))
+    cov = random_covariance(rng, dim=2)
+
+    coefs, vjp = coef_from_cov_grad(center, cov)
+    ref = coef_from_cov(center, cov)
+    np.testing.assert_allclose(coefs, ref, atol=1e-12)
+
+    m = coefs.shape[-1]
+    g = rng.standard_normal((1, m))
+    grad_X, grad_cov = vjp(g)
+    assert grad_X.shape == (1, 2)
+    assert grad_cov.shape == (1, 2, 2)
+
+
+def test_vjp_d4(rng):
+    """VJP correct for d=4 (higher dimension)."""
+    centers = rng.uniform(-3, 3, size=(2, 4))
+    covs = np.stack([random_covariance(rng, dim=4) for _ in range(2)])
+    _check_vjp_against_fd(centers, covs, scale=1.0, rng=rng)
+
+
+def test_grad_shapes(rng):
+    """Output shapes are correct."""
+    n, d = 4, 3
+    centers = rng.uniform(-5, 5, size=(n, d))
+    covs = np.stack([random_covariance(rng, dim=d) for _ in range(n)])
+
+    coefs, vjp = coef_from_cov_grad(centers, covs)
+    m = (d + 1) * (d + 2) // 2
+    assert coefs.shape == (n, m)
+
+    g = rng.standard_normal((n, m))
+    grad_X, grad_cov = vjp(g)
+    assert grad_X.shape == (n, d)
+    assert grad_cov.shape == (n, d, d)


### PR DESCRIPTION
## Summary
- Adds `coef_from_cov_grad(X, cov, *, scale)` to `ellphi.grad` — a differentiable version of `coef_from_cov` returning `(coefs, vjp)`
- VJP maps `grad_coefs (N, m)` → `(grad_centers (N, d), grad_cov (N, d, d))` using the matrix inverse derivative identity
- Works for arbitrary dimension d
- 9 new tests verifying VJP against central finite differences (d=2,3,4, rotated cov, various scales)

## Test plan
- [x] All 231 tests pass (`pytest tests/ -x -q`)
- [x] VJP verified against central FD to rel_error < 1e-5 for d=2,3,4
- [x] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)