### PR TITLE
ci: test docs workflow trigger on ellphi-0.1.2

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - docs/mkdocs-web-reference
+      - ellphi-0.1.2
   pull_request:
 
 permissions:


### PR DESCRIPTION
Switch the docs workflow push trigger from docs/mkdocs-web-reference to ellphi-0.1.2 so we can verify docs CI on the release branch before the version bump.