### PR TITLE
ci: split docs build from deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -4,14 +4,15 @@ on:
   push:
     branches:
       - main
-      - docs/mkdocs-web-reference
+      - "ellphi-*"
   pull_request:
+  workflow_dispatch:
 
 permissions:
   contents: write
 
 jobs:
-  deploy:
+  docs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -28,10 +29,9 @@ jobs:
       - name: Install dependencies
         run: poetry install --with docs
 
-      - name: Build and deploy
-        if: github.event_name == 'push'
-        run: poetry run mkdocs gh-deploy --force
-
-      - name: Build only (PR)
-        if: github.event_name == 'pull_request'
+      - name: Build docs
         run: poetry run mkdocs build
+
+      - name: Deploy to gh-pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: poetry run mkdocs gh-deploy --force

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -157,7 +157,7 @@ jobs:
         cd test_run
         pytest ../tests
 
-  build-docs:
+  demo-install:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -178,8 +178,4 @@ jobs:
         key: ${{ runner.os }}-poetry-${{ hashFiles('pyproject.toml') }}-v2
 
     - name: Install project (demo extras)
-      run: poetry install --with demo # Install core and demo dependencies
-
-    # Add steps for building documentation here, e.g., mkdocs build or sphinx build
-    # - name: Build documentation
-    #   run: poetry run mkdocs build
+      run: poetry install --with demo # Ensure the demo dependency set resolves


### PR DESCRIPTION
## Summary
- run docs builds on pull requests, release branches, and manual dispatches
- restrict gh-pages deployment to pushes on main only
- rename the misleading CI job from build-docs to demo-install

## Verification
- poetry run mkdocs build