### PR TITLE
Bump setuptools minimum version to 78.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,5 +111,5 @@ mypy_path = "src"
 allowlist = "stubtest-allowlist.txt"
 
 [build-system]
-requires = ["poetry-core>=1.9.0", "setuptools>=65"]
+requires = ["poetry-core>=1.9.0", "setuptools>=78.1.1"]
 build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
## Summary
Updates the minimum required version of setuptools in the build system dependencies from 65 to 78.1.1.

## Changes
- Updated `pyproject.toml` build-system requirements to specify `setuptools>=78.1.1` instead of `setuptools>=65`

## Details
This change ensures the project uses a more recent version of setuptools that likely includes important bug fixes, security updates, or features needed for the build process. The version bump from 65 to 78.1.1 represents a significant update that may address compatibility issues or improve build reliability.

https://claude.ai/code/session_01CUuVVqiQr32khYnEBz1eKD