### PR TITLE
docs: add CITATION.cff and cite the published JSIAM Letters paper

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use this software, please cite both the software and the paper below."
 type: software
-title: "ellphi"
+title: "EllPHi"
 abstract: "Fast ellipse tangency solver for anisotropic persistent homology."
 authors:
   - family-names: "Uda"

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,30 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite both the software and the paper below."
+type: software
+title: "ellphi"
+abstract: "Fast ellipse tangency solver for anisotropic persistent homology."
+authors:
+  - family-names: "Uda"
+    given-names: "Tomoki"
+license: MIT
+repository-code: "https://github.com/t-uda/ellphi"
+url: "https://github.com/t-uda/ellphi"
+version: "0.1.2"
+keywords:
+  - "topological data analysis"
+  - "computational geometry"
+  - "ellipse"
+  - "tangency"
+preferred-citation:
+  type: article
+  title: "Fast and accurate computation of ellipse tangency time for anisotropic persistent homology"
+  authors:
+    - family-names: "Uda"
+      given-names: "Tomoki"
+  journal: "JSIAM Letters"
+  volume: 18
+  year: 2026
+  start: 13
+  end: 16
+  doi: "10.14495/jsiaml.18.13"
+  url: "https://doi.org/10.14495/jsiaml.18.13"

--- a/README.md
+++ b/README.md
@@ -123,6 +123,35 @@ Build info (including the C++ linear algebra choice):
 python -m ellphi --build-info
 ```
 
+## Citation
+
+If you use EllPHi in your research, please cite the JSIAM Letters paper:
+
+> Tomoki Uda, *Fast and accurate computation of ellipse tangency time for
+> anisotropic persistent homology*, JSIAM Letters **18** (2026), 13–16.
+> DOI: [10.14495/jsiaml.18.13](https://doi.org/10.14495/jsiaml.18.13)
+> ([J-STAGE](https://www.jstage.jst.go.jp/article/jsiaml/18/0/18_13/_article/-char/en))
+
+BibTeX:
+
+```bibtex
+@article{Uda2026EllipseTangency,
+  author  = {Uda, Tomoki},
+  title   = {Fast and accurate computation of ellipse tangency time for
+             anisotropic persistent homology},
+  journal = {JSIAM Letters},
+  volume  = {18},
+  year    = {2026},
+  pages   = {13--16},
+  doi     = {10.14495/jsiaml.18.13},
+}
+```
+
+To cite the software itself, use the metadata in
+[`CITATION.cff`](https://github.com/t-uda/ellphi/blob/main/CITATION.cff) —
+GitHub's "Cite this repository" widget (in the sidebar of the repository
+page) generates APA and BibTeX entries from it.
+
 ## Contributing
 
 Interested in contributing? We welcome pull requests!

--- a/README.md
+++ b/README.md
@@ -125,12 +125,21 @@ python -m ellphi --build-info
 
 ## Citation
 
+Citation metadata for both the paper and the software is kept in
+[`CITATION.cff`](CITATION.cff).
+
+### Citing the paper
+
 If you use EllPHi in your research, please cite the JSIAM Letters paper:
 
 > Tomoki Uda, *Fast and accurate computation of ellipse tangency time for
 > anisotropic persistent homology*, JSIAM Letters **18** (2026), 13–16.
 > DOI: [10.14495/jsiaml.18.13](https://doi.org/10.14495/jsiaml.18.13)
 > ([J-STAGE](https://www.jstage.jst.go.jp/article/jsiaml/18/0/18_13/_article/-char/en))
+
+This is also what GitHub's "Cite this repository" widget (in the sidebar of
+the repository page) generates, via the `preferred-citation` entry in
+`CITATION.cff`.
 
 BibTeX:
 
@@ -147,10 +156,20 @@ BibTeX:
 }
 ```
 
-To cite the software itself, use the metadata in
-[`CITATION.cff`](https://github.com/t-uda/ellphi/blob/main/CITATION.cff) —
-GitHub's "Cite this repository" widget (in the sidebar of the repository
-page) generates APA and BibTeX entries from it.
+### Citing the software
+
+To cite the software itself:
+
+```bibtex
+@software{Uda2026EllPHi,
+  author  = {Uda, Tomoki},
+  title   = {EllPHi},
+  version = {0.1.2},
+  year    = {2026},
+  url     = {https://github.com/t-uda/ellphi},
+  license = {MIT},
+}
+```
 
 ## Contributing
 


### PR DESCRIPTION
## Summary

- Add root-level `CITATION.cff` (CFF 1.2.0) with software metadata consistent with `pyproject.toml` (name `ellphi`, author Tomoki Uda, MIT license, repository URL, version 0.1.2) and a `preferred-citation` of type `article` for the published paper:
  - Tomoki Uda, *Fast and accurate computation of ellipse tangency time for anisotropic persistent homology*, JSIAM Letters **18** (2026), 13–16. DOI: [10.14495/jsiaml.18.13](https://doi.org/10.14495/jsiaml.18.13)
- Add a "Citation" section to `README.md` with the paper reference, a ready-to-copy BibTeX entry, DOI and J-STAGE links, and a pointer to GitHub's "Cite this repository" widget backed by `CITATION.cff`.

Closes #127

## Verification

- `uvx cffconvert --validate` → "Citation metadata are valid according to schema version 1.2.0."
- `curl -sI https://doi.org/10.14495/jsiaml.18.13` → HTTP 302 redirect to the J-STAGE article page (DOI resolves).
- J-STAGE English article link (`.../_article/-char/en`) returns HTTP 200.
- No Python code changes, so the full AGENTS.md Python checklist (lint/type-check/tests) is not applicable to this PR.

## Deferred

- Docs-site (MkDocs, `docs/`) citation updates are deliberately deferred: the docs deployment is being reworked under #118, so this PR touches only `CITATION.cff` and `README.md`.

## Notes

- May need a trivial rebase after the Poetry→uv migration PR (#121) merges, since both touch `README.md` (different sections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)